### PR TITLE
Add new Hankel1 and BesselJ functions that work with CSE

### DIFF
--- a/sumpy/codegen.py
+++ b/sumpy/codegen.py
@@ -237,17 +237,16 @@ class BesselTopOrderGatherer(CSECachingMapperMixin, CallExternalRecMapper):
 
 
 class BesselDerivativeReplacer(CSECachingMapperMixin, CallExternalRecMapper):
-    def map_substitution(self, expr, rec_self=None, *args):
-        assert isinstance(expr.child, prim.Derivative)
-        call = expr.child.child
+    def map_call(self, expr, rec_self=None, *args):
+        call = expr
 
         if (isinstance(call.function, prim.Variable)
-                and call.function.name in ["hankel_1", "bessel_j"]):
-            function = call.function
-            order, _ = call.parameters
-            arg, = expr.values
-
-            n_derivs = len(expr.child.variables)
+                and call.function.name in ["Hankel1", "BesselJ"]):
+            if call.function.name == "Hankel1":
+                function = prim.Variable("hankel_1")
+            else:
+                function = prim.Variable("bessel_j")
+            order, arg, n_derivs = call.parameters
             import sympy as sym
 
             # AS (9.1.31)
@@ -263,7 +262,7 @@ class BesselDerivativeReplacer(CSECachingMapperMixin, CallExternalRecMapper):
                         for idx, i in enumerate(range(order-k, order+k+1, 2))),
                     "d%d_%s_%s" % (n_derivs, function.name, order_str))
         else:
-            return IdentityMapper.map_substitution(
+            return IdentityMapper.map_call(
                     rec_self if rec_self else self, expr, rec_self, *args)
 
     map_common_subexpression_uncached = IdentityMapper.map_common_subexpression

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -461,8 +461,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
         if not self.use_rscale:
             rscale = 1
 
-        from sumpy.symbolic import sym_real_norm_2
-        hankel_1 = sym.Function("hankel_1")
+        from sumpy.symbolic import sym_real_norm_2, Hankel1
 
         arg_scale = self.get_bessel_arg_scaling()
 
@@ -470,7 +469,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
         source_angle_rel_center = sym.atan2(-avec[1], -avec[0])
         avec_len = sym_real_norm_2(avec)
         return [kernel.postprocess_at_source(
-                    hankel_1(c, arg_scale * avec_len)
+                    Hankel1(c, arg_scale * avec_len, 0)
                     * rscale ** abs(c)
                     * sym.exp(sym.I * c * source_angle_rel_center), avec)
                     for c in self.get_coefficient_identifiers()]
@@ -479,8 +478,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
         if not self.use_rscale:
             rscale = 1
 
-        from sumpy.symbolic import sym_real_norm_2
-        bessel_j = sym.Function("bessel_j")
+        from sumpy.symbolic import sym_real_norm_2, BesselJ
         bvec_len = sym_real_norm_2(bvec)
         target_angle_rel_center = sym.atan2(bvec[1], bvec[0])
 
@@ -488,14 +486,14 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
 
         return sum(coeffs[self.get_storage_index(c)]
                    * kernel.postprocess_at_target(
-                       bessel_j(c, arg_scale * bvec_len)
+                       BesselJ(c, arg_scale * bvec_len, 0)
                        / rscale ** abs(c)
                        * sym.exp(sym.I * c * -target_angle_rel_center), bvec)
                 for c in self.get_coefficient_identifiers())
 
     def translate_from(self, src_expansion, src_coeff_exprs, src_rscale,
             dvec, tgt_rscale, sac=None):
-        from sumpy.symbolic import sym_real_norm_2
+        from sumpy.symbolic import sym_real_norm_2, BesselJ, Hankel1
 
         if not self.use_rscale:
             src_rscale = 1
@@ -505,13 +503,12 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
 
         if isinstance(src_expansion, type(self)):
             dvec_len = sym_real_norm_2(dvec)
-            bessel_j = sym.Function("bessel_j")
             new_center_angle_rel_old_center = sym.atan2(dvec[1], dvec[0])
             translated_coeffs = []
             for j in self.get_coefficient_identifiers():
                 translated_coeffs.append(
                     sum(src_coeff_exprs[src_expansion.get_storage_index(m)]
-                        * bessel_j(m - j, arg_scale * dvec_len)
+                        * BesselJ(m - j, arg_scale * dvec_len, 0)
                         / src_rscale ** abs(m)
                         * tgt_rscale ** abs(j)
                         * sym.exp(sym.I * (m - j) * -new_center_angle_rel_old_center)
@@ -520,14 +517,13 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
 
         if isinstance(src_expansion, self.mpole_expn_class):
             dvec_len = sym_real_norm_2(dvec)
-            hankel_1 = sym.Function("hankel_1")
             new_center_angle_rel_old_center = sym.atan2(dvec[1], dvec[0])
             translated_coeffs = []
             for j in self.get_coefficient_identifiers():
                 translated_coeffs.append(
                     sum(
                         sym.Integer(-1) ** j
-                        * hankel_1(m + j, arg_scale * dvec_len)
+                        * Hankel1(m + j, arg_scale * dvec_len, 0)
                         * src_rscale ** abs(m)
                         * tgt_rscale ** abs(j)
                         * sym.exp(sym.I * (m + j) * new_center_angle_rel_old_center)

--- a/sumpy/expansion/multipole.py
+++ b/sumpy/expansion/multipole.py
@@ -405,8 +405,7 @@ class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
         if kernel is None:
             kernel = self.kernel
 
-        from sumpy.symbolic import sym_real_norm_2
-        bessel_j = sym.Function("bessel_j")
+        from sumpy.symbolic import sym_real_norm_2, BesselJ
         avec_len = sym_real_norm_2(avec)
 
         arg_scale = self.get_bessel_arg_scaling()
@@ -415,7 +414,7 @@ class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
         source_angle_rel_center = sym.atan2(-avec[1], -avec[0])
         return [
                 kernel.postprocess_at_source(
-                    bessel_j(c, arg_scale * avec_len)
+                    BesselJ(c, arg_scale * avec_len, 0)
                     / rscale ** abs(c)
                     * sym.exp(sym.I * c * -source_angle_rel_center),
                     avec)
@@ -425,8 +424,7 @@ class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
         if not self.use_rscale:
             rscale = 1
 
-        from sumpy.symbolic import sym_real_norm_2
-        hankel_1 = sym.Function("hankel_1")
+        from sumpy.symbolic import sym_real_norm_2, Hankel1
         bvec_len = sym_real_norm_2(bvec)
         target_angle_rel_center = sym.atan2(bvec[1], bvec[0])
 
@@ -434,7 +432,7 @@ class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
 
         return sum(coeffs[self.get_storage_index(c)]
                    * kernel.postprocess_at_target(
-                       hankel_1(c, arg_scale * bvec_len)
+                       Hankel1(c, arg_scale * bvec_len, 0)
                        * rscale ** abs(c)
                        * sym.exp(sym.I * c * target_angle_rel_center), bvec)
                 for c in self.get_coefficient_identifiers())
@@ -450,9 +448,8 @@ class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
             src_rscale = 1
             tgt_rscale = 1
 
-        from sumpy.symbolic import sym_real_norm_2
+        from sumpy.symbolic import sym_real_norm_2, BesselJ
         dvec_len = sym_real_norm_2(dvec)
-        bessel_j = sym.Function("bessel_j")
         new_center_angle_rel_old_center = sym.atan2(dvec[1], dvec[0])
 
         arg_scale = self.get_bessel_arg_scaling()
@@ -461,7 +458,7 @@ class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
         for j in self.get_coefficient_identifiers():
             translated_coeffs.append(
                 sum(src_coeff_exprs[src_expansion.get_storage_index(m)]
-                    * bessel_j(m - j, arg_scale * dvec_len)
+                    * BesselJ(m - j, arg_scale * dvec_len, 0)
                     * src_rscale ** abs(m)
                     / tgt_rscale ** abs(j)
                     * sym.exp(sym.I * (m - j) * new_center_angle_rel_old_center)

--- a/sumpy/symbolic.py
+++ b/sumpy/symbolic.py
@@ -267,9 +267,8 @@ class _BesselOrHankel(sympy.Function):
         if argindex in (1, 3):
             # we are not differentiating w.r.t order or nderivs
             return 0
-        args = list(self.args)
-        args[-1] += 1
-        return self.func(*args)
+        order, z, nderivs = self.args
+        return self.func(order, z, nderivs+1)
 
 
 class BesselJ(_BesselOrHankel):

--- a/sumpy/symbolic.py
+++ b/sumpy/symbolic.py
@@ -267,7 +267,7 @@ class _BesselOrHankel(sympy.Function):
     def fdiff(self, argindex=1):
         if argindex in (1, 3):
             # we are not differentiating w.r.t order or nderivs
-            return 0
+            raise ValueError()
         order, z, nderivs = self.args
         return self.func(order, z, nderivs+1)
 

--- a/sumpy/symbolic.py
+++ b/sumpy/symbolic.py
@@ -259,8 +259,9 @@ import sympy
 
 class _BesselOrHankel(sympy.Function):
     """A symbolic function for BesselJ or Hankel1 functions
-    that keeps track of the derivatives taken of the function
-    arguments are (order, z, nderivs)"""
+    that keeps track of the derivatives taken of the function.
+    Arguments are ``(order, z, nderivs)``.
+    """
     nargs = (3,)
 
     def fdiff(self, argindex=1):


### PR DESCRIPTION
Since Derivatives and Subs are not CSEed due to some issues
derivatives of hankel1 functions and hankel1 functions
end up with different arguments and code generation treats
them seperately. See https://github.com/inducer/sumpy/blob/0fc6535b6ef803e2a8ebd418162274634aead6f9/sumpy/cse.py#L84

Fixes https://github.com/inducer/sumpy/issues/61