### PR TITLE
Track TreeIndependentData refactor from boxtree, remove persistent queue from wrangler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
             run: |
                 curl -L -O https://tiker.net/ci-support-v0
                 . ./ci-support-v0
-                if [[ "$DOWNSTREAM_PROJECT" = "pytential" ]] && [[ "$GITHUB_HEAD_REF" = "remove-block-index-ranges" ]]; then
-                  git clone "https://github.com/alexfikl/$DOWNSTREAM_PROJECT.git" -b "block-index-ranges"
+                if [[ "$DOWNSTREAM_PROJECT" = "pytential" ]] && [[ "$GITHUB_HEAD_REF" = "wrangler-refactor" ]]; then
+                  git clone "https://github.com/inducer/$DOWNSTREAM_PROJECT.git" -b "wrangler-refactor"
                 else
                   git clone "https://github.com/inducer/$DOWNSTREAM_PROJECT.git"
                 fi


### PR DESCRIPTION
This tracks the refactor of the wrangler and its tree-independent data in https://github.com/inducer/boxtree/pull/29.

Draft because:
- [x] Needs https://github.com/inducer/boxtree/pull/29
- [ ] Should go in at the same time as https://github.com/inducer/pytential/pull/101
- [x] `requirements.txt` modification needs to be reverted