### PR TITLE
Revert "Restrict pocl to <=1.6 for cuda-atomic bug"

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -7,10 +7,7 @@ dependencies:
 - git
 - numpy
 - sympy
-
-# https://github.com/pocl/pocl/issues/955
-- pocl<=1.6
-
+- pocl
 - pocl-cuda
 - islpy
 - pyopencl


### PR DESCRIPTION
This reverts commit 596b33c3a5e36189b7340699a430db688f024a8a.

This issue was fixed in the conda package. https://github.com/conda-forge/pocl-feedstock/pull/65