### PR TITLE
Revert "Revert "Restrict pocl to <=1.6 for cuda-atomic bug""

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -7,7 +7,10 @@ dependencies:
 - git
 - numpy
 - sympy
-- pocl
+
+# https://github.com/pocl/pocl/issues/955
+- pocl<=1.6
+
 - pocl-cuda
 - islpy
 - pyopencl


### PR DESCRIPTION
Reverts inducer/sumpy#74

Removing the version restriction broke Gitlab CI, e.g. here: https://gitlab.tiker.net/inducer/sumpy/-/jobs/291349

cc @isuruf 