### PR TITLE
Fix rscale dtype inference when using object arrays

### DIFF
--- a/sumpy/p2e.py
+++ b/sumpy/p2e.py
@@ -144,7 +144,8 @@ class P2EBase(KernelComputation, KernelCacheWrapper):
 
         # "1" may be passed for rscale, which won't have its type
         # meaningfully inferred. Make the type of rscale explicit.
-        rscale = centers.dtype.type(kwargs.pop("rscale"))
+        dtype = centers[0].dtype if is_obj_array_like(centers) else centers.dtype
+        rscale = dtype.type(kwargs.pop("rscale"))
 
         return knl(queue, sources=sources, centers=centers, rscale=rscale, **kwargs)
 


### PR DESCRIPTION
Managed to spot an error in #76.

On the other hand, no one is using the object array support in the P2E classes, so I'm fine with deleting it altogether too. It was initially meant for pytential, since all the `nodes()` are object arrays.