### PR TITLE
Check AxisTargetDerivative on TargetPointMultiplier

### DIFF
--- a/sumpy/expansion/multipole.py
+++ b/sumpy/expansion/multipole.py
@@ -91,6 +91,11 @@ class VolumeTaylorMultipoleExpansionBase(MultipoleExpansionBase):
             rscale = 1
 
         base_taker = kernel.get_derivative_taker(bvec, rscale, sac)
+        # Following is a no-op, but reduces the cases we have to handle
+        # in AxisTargetDerivative.postprocess_at_target and
+        # DirectionalTargetDerivative.postprocess_at_target because
+        # the type will always be DifferentiatedExprDerivativeTaker
+        # that we are passing to postprocess_at_target
         base_taker = DifferentiatedExprDerivativeTaker(base_taker,
                 {tuple([0]*self.dim): 1})
         taker = kernel.postprocess_at_target(base_taker, bvec)

--- a/sumpy/expansion/multipole.py
+++ b/sumpy/expansion/multipole.py
@@ -93,7 +93,7 @@ class VolumeTaylorMultipoleExpansionBase(MultipoleExpansionBase):
         base_taker = kernel.get_derivative_taker(bvec, rscale, sac)
         # Following is a no-op, but AxisTargetDerivative.postprocess_at_target and
         # DirectionalTargetDerivative.postprocess_at_target only handles
-        # DifferentiatedExprDerivativeTaker and sympy expression, so we need to
+        # DifferentiatedExprDerivativeTaker and sympy expressions, so we need to
         # make the taker a DifferentitatedExprDerivativeTaker instance.
         base_taker = DifferentiatedExprDerivativeTaker(base_taker,
                 {tuple([0]*self.dim): 1})

--- a/sumpy/expansion/multipole.py
+++ b/sumpy/expansion/multipole.py
@@ -91,11 +91,10 @@ class VolumeTaylorMultipoleExpansionBase(MultipoleExpansionBase):
             rscale = 1
 
         base_taker = kernel.get_derivative_taker(bvec, rscale, sac)
-        # Following is a no-op, but reduces the cases we have to handle
-        # in AxisTargetDerivative.postprocess_at_target and
-        # DirectionalTargetDerivative.postprocess_at_target because
-        # the type will always be DifferentiatedExprDerivativeTaker
-        # that we are passing to postprocess_at_target
+        # Following is a no-op, but AxisTargetDerivative.postprocess_at_target and
+        # DirectionalTargetDerivative.postprocess_at_target only handles
+        # DifferentiatedExprDerivativeTaker and sympy expression, so we need to
+        # make the taker a DifferentitatedExprDerivativeTaker instance.
         base_taker = DifferentiatedExprDerivativeTaker(base_taker,
                 {tuple([0]*self.dim): 1})
         taker = kernel.postprocess_at_target(base_taker, bvec)

--- a/sumpy/expansion/multipole.py
+++ b/sumpy/expansion/multipole.py
@@ -86,10 +86,13 @@ class VolumeTaylorMultipoleExpansionBase(MultipoleExpansionBase):
                 rscale, (1,), sac=sac)
 
     def evaluate(self, kernel, coeffs, bvec, rscale, sac=None):
+        from sumpy.tools import DifferentiatedExprDerivativeTaker
         if not self.use_rscale:
             rscale = 1
 
         base_taker = kernel.get_derivative_taker(bvec, rscale, sac)
+        base_taker = DifferentiatedExprDerivativeTaker(base_taker,
+                {tuple([0]*self.dim): 1})
         taker = kernel.postprocess_at_target(base_taker, bvec)
 
         result = []

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -1030,12 +1030,15 @@ class AxisTargetDerivative(DerivativeBase):
 
         target_vec = make_sympy_vector(self.target_array_name, self.dim)
 
+        # bvec = tgt - ctr
         expr = self.inner_kernel.postprocess_at_target(expr, bvec)
         if isinstance(expr, DifferentiatedExprDerivativeTaker):
             transformation = diff_transformation(expr.derivative_transformation,
                     self.axis, target_vec)
             return DifferentiatedExprDerivativeTaker(expr.taker, transformation)
         else:
+            # Since `bvec` and `tgt` are two different symbolic variables
+            # need to differentiate by both to get the correct answer
             return expr.diff(bvec[self.axis]) + expr.diff(target_vec[self.axis])
 
     def replace_base_kernel(self, new_base_kernel):
@@ -1133,6 +1136,8 @@ class DirectionalTargetDerivative(DirectionalDerivative):
         if not isinstance(expr, DifferentiatedExprDerivativeTaker):
             result = 0
             for axis in range(self.dim):
+                # Since `bvec` and `tgt` are two different symbolic variables
+                # need to differentiate by both to get the correct answer
                 result += (expr.diff(bvec[axis]) + expr.diff(target_vec[axis])) \
                         * dir_vec[axis]
             return result

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -238,7 +238,7 @@ class Kernel:
 
         The typical use of this function is to apply target-variable
         derivatives to the kernel.
-        
+
         :arg expr: may be a :class:`sympy.Expr` or a
             :class:`sumpy.tools.DifferentiatedExprDerivativeTaker`.
         """

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -239,7 +239,7 @@ class Kernel:
         The typical use of this function is to apply target-variable
         derivatives to the kernel.
 
-        :arg expr: may be a :class:`sympy.Expr` or a
+        :arg expr: may be a :class:`sympy.core.expr.Expr` or a
             :class:`sumpy.tools.DifferentiatedExprDerivativeTaker`.
         """
         return expr

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -238,6 +238,9 @@ class Kernel:
 
         The typical use of this function is to apply target-variable
         derivatives to the kernel.
+        
+        :arg expr: may be a :class:`sympy.Expr` or a
+            :class:`sumpy.tools.DifferentiatedExprDerivativeTaker`.
         """
         return expr
 

--- a/sumpy/tools.py
+++ b/sumpy/tools.py
@@ -46,6 +46,7 @@ import numpy as np
 import sumpy.symbolic as sym
 
 import loopy as lp
+from typing import Dict, Tuple, Any
 
 import logging
 logger = logging.getLogger(__name__)
@@ -394,6 +395,9 @@ class HelmholtzDerivativeTaker(RadialDerivativeTaker):
         return expr
 
 
+DerivativeCoeffDict = Dict[Tuple[int], Any]
+
+
 @tag_dataclass
 class DifferentiatedExprDerivativeTaker:
     """Implements the :class:`ExprDerivativeTaker` interface
@@ -411,7 +415,7 @@ class DifferentiatedExprDerivativeTaker:
         base expression.
     """
     taker: ExprDerivativeTaker
-    derivative_coeff_dict: dict
+    derivative_coeff_dict: DerivativeCoeffDict
 
     def diff(self, mi, save_intermediate=lambda x: x):
         # By passing `rscale` to the derivative taker we are taking a scaled
@@ -432,7 +436,8 @@ class DifferentiatedExprDerivativeTaker:
         return result * save_intermediate(1 / self.taker.rscale ** max_order)
 
 
-def diff_derivative_coeff_dict(derivative_coeff_dict, variable_idx, variables):
+def diff_derivative_coeff_dict(derivative_coeff_dict: DerivativeCoeffDict,
+        variable_idx, variables):
     """Differentiate a derivative transformation dictionary given by
     *derivative_coeff_dict* using the variable given by **variable_idx**
     and return a new derivative transformation dictionary.

--- a/sumpy/tools.py
+++ b/sumpy/tools.py
@@ -39,6 +39,7 @@ __doc__ = """
 from pytools import memoize_method
 from pytools.tag import Tag, tag_dataclass
 import numbers
+from collections import defaultdict
 from pymbolic.mapper import WalkMapper
 
 import numpy as np
@@ -429,6 +430,18 @@ class DifferentiatedExprDerivativeTaker:
             for extra_mi, coeff in self.derivative_transformation.items())
 
         return result * save_intermediate(1 / self.taker.rscale ** max_order)
+
+
+def diff_transformation(derivative_transformation, variable_idx, variables):
+    new_transformation = defaultdict(lambda: 0)
+    for mi, coeff in derivative_transformation.items():
+        new_coeff = sym.sympify(coeff).diff(variables[variable_idx])
+        if new_coeff != 0:
+            new_transformation[mi] += new_coeff
+        new_mi = list(mi)
+        new_mi[variable_idx] += 1
+        new_transformation[tuple(new_mi)] += coeff
+    return dict(new_transformation)
 
 # }}}
 

--- a/sumpy/tools.py
+++ b/sumpy/tools.py
@@ -437,19 +437,19 @@ def diff_transformation(derivative_transformation, variable_idx, variables):
     variable given by **variable_idx** and return a new derivative transformation
     dictionary
     """
-    new_transformation = defaultdict(lambda: 0)
+    new_derivative_coeff_dict = defaultdict(lambda: 0)
     for mi, coeff in derivative_transformation.items():
         # In the case where we have x * u.diff(x), the result should
         # be x.diff(x) + x * u.diff(x, x)
         # Calculate the first term by differentiating the coefficients
         new_coeff = sym.sympify(coeff).diff(variables[variable_idx])
         if new_coeff != 0:
-            new_transformation[mi] += new_coeff
+            new_derivative_coeff_dict[mi] += new_coeff
         # Next calculate the second term by differentitating the derivatives
         new_mi = list(mi)
         new_mi[variable_idx] += 1
-        new_transformation[tuple(new_mi)] += coeff
-    return dict(new_transformation)
+        new_derivative_coeff_dict[tuple(new_mi)] += coeff
+    return dict(new_derivative_coeff_dict)
 
 # }}}
 

--- a/sumpy/tools.py
+++ b/sumpy/tools.py
@@ -443,13 +443,13 @@ def diff_transformation(derivative_transformation, variable_idx, variables):
         # be x.diff(x) + x * u.diff(x, x)
         # Calculate the first term by differentiating the coefficients
         new_coeff = sym.sympify(coeff).diff(variables[variable_idx])
-        if new_coeff != 0:
-            new_derivative_coeff_dict[mi] += new_coeff
-        # Next calculate the second term by differentitating the derivatives
+        new_derivative_coeff_dict[mi] += new_coeff
+        # Next calculate the second term by differentiating the derivatives
         new_mi = list(mi)
         new_mi[variable_idx] += 1
         new_derivative_coeff_dict[tuple(new_mi)] += coeff
-    return dict(new_derivative_coeff_dict)
+    return {derivative: coeff for derivative, coeff in
+            new_derivative_coeff_dict.items() if coeff != 0}
 
 # }}}
 

--- a/sumpy/tools.py
+++ b/sumpy/tools.py
@@ -433,11 +433,19 @@ class DifferentiatedExprDerivativeTaker:
 
 
 def diff_transformation(derivative_transformation, variable_idx, variables):
+    """Differentiate a derivative transformation dictionary using the
+    variable given by **variable_idx** and return a new derivative transformation
+    dictionary
+    """
     new_transformation = defaultdict(lambda: 0)
     for mi, coeff in derivative_transformation.items():
+        # In the case where we have x * u.diff(x), the result should
+        # be x.diff(x) + x * u.diff(x, x)
+        # Calculate the first term by differentiating the coefficients
         new_coeff = sym.sympify(coeff).diff(variables[variable_idx])
         if new_coeff != 0:
             new_transformation[mi] += new_coeff
+        # Next calculate the second term by differentitating the derivatives
         new_mi = list(mi)
         new_mi[variable_idx] += 1
         new_transformation[tuple(new_mi)] += coeff


### PR DESCRIPTION
This tests an `AxisTargetDerivative` on a `TargetPointMultiplier` and it's not quite working as expected. 

At least in the case `AxisTargetDerivative(1, TargetPointMultiplier(0, knl))`, I would expect the target derivative to not do much, since the multiplier is on a different component, so it should be equivalent to `TargetPointMultiplier(0, AxisTargetDerivative(1, knl))`. Am I misunderstanding that?

This is more of a question-PR, so
* Does `TargetPointMultiplier` actually support derivatives?
* If yes, is this the right way to apply / check them?