### PR TITLE
Direct loopy kernel

### DIFF
--- a/sumpy/__init__.py
+++ b/sumpy/__init__.py
@@ -26,7 +26,8 @@ from sumpy.p2e import P2EFromSingleBox, P2EFromCSR
 from sumpy.e2p import E2PFromSingleBox, E2PFromCSR
 from sumpy.e2e import (E2EFromCSR, E2EFromChildren, E2EFromParent,
     M2LUsingTranslationClassesDependentData,
-    M2LGenerateTranslationClassesDependentData, M2LPreprocessMultipole)
+    M2LGenerateTranslationClassesDependentData, M2LPreprocessMultipole,
+    M2LPostprocessLocal)
 from sumpy.version import VERSION_TEXT
 from pytools.persistent_dict import WriteOncePersistentDict
 
@@ -37,7 +38,7 @@ __all__ = [
     "E2EFromCSR", "E2EFromChildren", "E2EFromParent",
     "M2LUsingTranslationClassesDependentData",
     "M2LGenerateTranslationClassesDependentData",
-    "M2LPreprocessMultipole"]
+    "M2LPreprocessMultipole", "M2LPostprocessLocal"]
 
 
 code_cache = WriteOncePersistentDict("sumpy-code-cache-v6-"+VERSION_TEXT)

--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -776,7 +776,7 @@ class E2EFromChildren(E2EBase):
                    % type(self).__name__)
 
         ncoeffs_src = len(self.src_expansion)
-        ncoeffs_tgt = len(self.src_expansion)
+        ncoeffs_tgt = len(self.tgt_expansion)
 
         # To clarify terminology:
         #

--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -351,8 +351,14 @@ class M2LUsingTranslationClassesDependentData(E2EFromCSR):
 
         ndata = self.tgt_expansion.m2l_translation_classes_dependent_ndata(
                         self.src_expansion)
-        ncoeff_src = len(self.src_expansion)
-        ncoeff_tgt = len(self.src_expansion)
+        if self.tgt_expansion.use_preprocessing_for_m2l:
+            ncoeff_src = self.tgt_expansion.m2l_preprocess_multipole_nexprs(
+                    self.src_expansion)
+            ncoeff_tgt = self.tgt_expansion.m2l_postprocess_local_nexprs(
+                    self.src_expansion)
+        else:
+            ncoeff_src = len(self.src_expansion)
+            ncoeff_tgt = len(self.tgt_expansion)
 
         domains = []
         insns = self.get_translation_loopy_insns(result_dtype)

--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -23,7 +23,6 @@ THE SOFTWARE.
 import numpy as np
 import loopy as lp
 import sumpy.symbolic as sym
-import pymbolic
 
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
 from sumpy.tools import KernelCacheWrapper, to_complex_dtype
@@ -427,10 +426,6 @@ class M2LUsingTranslationClassesDependentData(E2EFromCSR):
         tgt_rscale = centers.dtype.type(kwargs.pop("tgt_rscale"))
 
         knl = self.get_cached_optimized_kernel()
-        ncoeff_src = self.tgt_expansion.m2l_preprocess_multipole_nexprs(
-                    self.src_expansion)
-        ncoeff_tgt = self.tgt_expansion.m2l_postprocess_local_nexprs(
-                    self.src_expansion)
 
         return knl(queue,
                 centers=centers,

--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -381,10 +381,14 @@ class M2LUsingTranslationClassesDependentData(E2EFromCSR):
                 self.tgt_expansion.m2l_translation_classes_dependent_ndata(
                         self.src_expansion)
 
-        ncoeff_src = self.tgt_expansion.m2l_preprocess_multipole_nexprs(
-                    self.src_expansion) or len(self.src_expansion)
-        ncoeff_tgt = self.tgt_expansion.m2l_postprocess_local_nexprs(
-                    self.src_expansion) or len(self.tgt_expansion)
+        if self.tgt_expansion.use_preprocessing_for_m2l:
+            ncoeff_src = self.tgt_expansion.m2l_preprocess_multipole_nexprs(
+                    self.src_expansion)
+            ncoeff_tgt = self.tgt_expansion.m2l_postprocess_local_nexprs(
+                    self.src_expansion)
+        else:
+            ncoeff_src = len(self.src_expansion)
+            ncoeff_tgt = len(self.tgt_expansion)
 
         # To clarify terminology:
         #

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -82,8 +82,8 @@ class LocalExpansionBase(ExpansionBase):
 
     def update_persistent_hash(self, key_hash, key_builder):
         super().update_persistent_hash(key_hash, key_builder)
-        key_builder.rec(key_hash, self.use_fft_for_m2l,
-                self.use_preprocessing_for_m2l)
+        key_builder.rec(key_hash, self.use_fft_for_m2l)
+        key_builder.rec(key_hash, self.use_preprocessing_for_m2l)
 
     def __eq__(self, other):
         return (

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -967,8 +967,6 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                                type(self).__name__))
 
     def loopy_translate_from(self, src_expansion):
-        from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansionBase
-
         if isinstance(src_expansion, self.mpole_expn_class):
             ncoeff_src = self.m2l_preprocess_multipole_nexprs(src_expansion)
             ncoeff_tgt = self.m2l_postprocess_local_nexprs(src_expansion)

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -475,13 +475,9 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
             return input_vector
 
     def m2l_preprocess_multipole_nexprs(self, src_expansion):
-        if self.use_fft_for_m2l:
-            circulant_matrix_mis, _, _ = \
-                self._m2l_translation_classes_dependent_data_mis(src_expansion)
-            return len(circulant_matrix_mis)
-        else:
-            # Don't use preprocessing
-            return 0
+        circulant_matrix_mis, _, _ = \
+            self._m2l_translation_classes_dependent_data_mis(src_expansion)
+        return len(circulant_matrix_mis)
 
     def m2l_postprocess_local_exprs(self, src_expansion, m2l_result, src_rscale,
             tgt_rscale, sac):
@@ -507,11 +503,7 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
         return result
 
     def m2l_postprocess_local_nexprs(self, src_expansion):
-        if self.use_fft_for_m2l or self.use_preprocessing_for_m2l:
-            return self.m2l_translation_classes_dependent_ndata(src_expansion)
-        else:
-            # Don't use preprocessing
-            return 0
+        return self.m2l_translation_classes_dependent_ndata(src_expansion)
 
     def translate_from(self, src_expansion, src_coeff_exprs, src_rscale,
             dvec, tgt_rscale, sac=None, _fast_version=True,
@@ -924,11 +916,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
             return src_coeff_exprs
 
     def m2l_preprocess_multipole_nexprs(self, src_expansion):
-        if self.use_fft_for_m2l or self.use_preprocessing_for_m2l:
-            return 2*src_expansion.order + 1
-        else:
-            # Don't use preprocessing
-            return 0
+        return 2*src_expansion.order + 1
 
     def m2l_postprocess_local_exprs(self, src_expansion, m2l_result, src_rscale,
             tgt_rscale, sac):
@@ -946,11 +934,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
         return result
 
     def m2l_postprocess_local_nexprs(self, src_expansion):
-        if self.use_fft_for_m2l or self.use_preprocessing_for_m2l:
-            return 2*self.order + 1
-        else:
-            # Don't use postprocessing
-            return 0
+        return 2*self.order + 1
 
     def translate_from(self, src_expansion, src_coeff_exprs, src_rscale,
             dvec, tgt_rscale, sac=None, m2l_translation_classes_dependent_data=None):

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -731,7 +731,9 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
                         name="e2e",
                         lang_version=lp.MOST_RECENT_LANGUAGE_VERSION,
                         )
-        raise NotImplementedError("")
+        raise NotImplementedError(
+            f"A direct loopy kernel for translation from "
+            f"{src_expansion} to {self} is not implemented.")
 
 
 class VolumeTaylorLocalExpansion(
@@ -978,8 +980,9 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                 translated_coeffs = [a * b for a, b in zip(derivatives,
                     src_coeff_exprs)]
             else:
-                src_coeff_exprs = self.m2l_preprocess_multipole_exprs(src_expansion,
-                        src_coeff_exprs, sac, src_rscale)
+                if self.use_preprocessing_for_m2l:
+                    src_coeff_exprs = self.m2l_preprocess_multipole_exprs(
+                        src_expansion, src_coeff_exprs, sac, src_rscale)
 
                 translated_coeffs = [
                     sum(derivatives[m + j + self.order + src_expansion.order]
@@ -987,8 +990,10 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                         for m in src_expansion.get_coefficient_identifiers())
                     for j in self.get_coefficient_identifiers()]
 
-                translated_coeffs = self.m2l_postprocess_local_exprs(src_expansion,
-                        translated_coeffs, src_rscale, tgt_rscale, sac)
+                if self.use_preprocessing_for_m2l:
+                    translated_coeffs = self.m2l_postprocess_local_exprs(
+                        src_expansion, translated_coeffs, src_rscale, tgt_rscale,
+                        sac)
 
             return translated_coeffs
 

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -690,7 +690,7 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
                 icoeff_tgt = pymbolic.var("icoeff_tgt")
                 domains = [f"{{[icoeff_tgt]: 0<=icoeff_tgt<{ncoeff_tgt} }}"]
 
-                coeff = pymbolic.var("src_coeffs")
+                coeff = pymbolic.var("coeff")
                 src_coeffs = pymbolic.var("src_coeffs")
                 m2l_translation_classes_dependent_data = pymbolic.var("data")
 

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -753,7 +753,7 @@ class LinearPDEConformingVolumeTaylorLocalExpansion(
         VolumeTaylorLocalExpansionBase):
 
     def __init__(self, kernel, order, use_rscale=None,
-            use_fft_for_m2l=False, use_preprocessing_for_m2l):
+            use_fft_for_m2l=False, use_preprocessing_for_m2l=None):
         VolumeTaylorLocalExpansionBase.__init__(self, kernel, order, use_rscale,
                 use_fft_for_m2l, use_preprocessing_for_m2l)
         LinearPDEConformingVolumeTaylorExpansion.__init__(
@@ -1051,7 +1051,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
 
 class H2DLocalExpansion(_FourierBesselLocalExpansion):
     def __init__(self, kernel, order, use_rscale=None,
-            use_fft_for_m2l=False, use_preprocessing_for_m2l):
+            use_fft_for_m2l=False, use_preprocessing_for_m2l=None):
         from sumpy.kernel import HelmholtzKernel
         assert (isinstance(kernel.get_base_kernel(), HelmholtzKernel)
                 and kernel.dim == 2)
@@ -1069,7 +1069,7 @@ class H2DLocalExpansion(_FourierBesselLocalExpansion):
 
 class Y2DLocalExpansion(_FourierBesselLocalExpansion):
     def __init__(self, kernel, order, use_rscale=None,
-            use_fft_for_m2l=False, use_preprocessing_for_m2l):
+            use_fft_for_m2l=False, use_preprocessing_for_m2l=None):
         from sumpy.kernel import YukawaKernel
         assert (isinstance(kernel.get_base_kernel(), YukawaKernel)
                 and kernel.dim == 2)

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -1016,7 +1016,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                         )
         raise NotImplementedError(
             f"A direct loopy kernel for translation from "
-            f"{self.src_expansion} to {self.tgt_expansion} is not implemented.")
+            f"{src_expansion} to {self} is not implemented.")
 
 
 class H2DLocalExpansion(_FourierBesselLocalExpansion):

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -698,6 +698,7 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
 
         if isinstance(src_expansion, VolumeTaylorMultipoleExpansionBase):
             if self.use_preprocessing_for_m2l:
+                ncoeff_src = self.m2l_preprocess_multipole_nexprs(src_expansion)
                 ncoeff_tgt = self.m2l_postprocess_local_nexprs(src_expansion)
                 icoeff_src = pymbolic.var("icoeff_src")
                 icoeff_tgt = pymbolic.var("icoeff_tgt")
@@ -1010,6 +1011,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
     def loopy_translate_from(self, src_expansion):
         if isinstance(src_expansion, self.mpole_expn_class):
             if self.use_preprocessing_for_m2l:
+                ncoeff_src = self.m2l_preprocess_multipole_nexprs(src_expansion)
                 ncoeff_tgt = self.m2l_postprocess_local_nexprs(src_expansion)
 
                 icoeff_src = pymbolic.var("icoeff_src")

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -690,15 +690,18 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
                 icoeff_tgt = pymbolic.var("icoeff_tgt")
                 domains = [f"{{[icoeff_tgt]: 0<=icoeff_tgt<{ncoeff_tgt} }}"]
 
+                coeff = pymbolic.var("src_coeffs")
                 src_coeffs = pymbolic.var("src_coeffs")
                 m2l_translation_classes_dependent_data = pymbolic.var("data")
 
                 expr = src_coeffs[icoeff_tgt] \
                     * m2l_translation_classes_dependent_data[icoeff_tgt]
 
-                insns = f"""
-                coeff[icoeff_tgt] = coeff[icoeff_tgt] + {expr}
-                """
+                insns = [
+                    lp.Assignment(
+                        assignee=coeff[icoeff_tgt],
+                        expression=coeff[icoeff_tgt] + expr),
+                ]
                 return lp.make_function(domains, insns,
                         kernel_data=[
                             lp.GlobalArg("coeff, src_coeffs, data",
@@ -988,15 +991,18 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                 icoeff_tgt = pymbolic.var("icoeff_tgt")
                 domains = [f"{{[icoeff_tgt]: 0<=icoeff_tgt<{ncoeff_tgt} }}"]
 
+                coeff = pymbolic.var("coeff")
                 src_coeffs = pymbolic.var("src_coeffs")
                 m2l_translation_classes_dependent_data = pymbolic.var("data")
 
                 expr = src_coeffs[icoeff_tgt] \
                             * m2l_translation_classes_dependent_data[icoeff_tgt]
 
-                insns = f"""
-                coeff[icoeff_tgt] = coeff[icoeff_tgt] + {expr}
-                """
+                insns = [
+                    lp.Assignment(
+                        assignee=coeff[icoeff_tgt],
+                        expression=coeff[icoeff_tgt] + expr),
+                ]
                 return lp.make_function(domains, insns,
                         kernel_data=[
                             lp.GlobalArg("coeff, src_coeffs, data",

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -539,7 +539,8 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
                 src_coeff_exprs = self.m2l_preprocess_multipole_exprs(src_expansion,
                         src_coeff_exprs, sac, src_rscale)
                 # Returns a big symbolic sum of matrix entries
-                # (FIXME? Though this is just the correctness-checking fallback for the FFT anyhow)
+                # (FIXME? Though this is just the correctness-checking
+                # fallback for the FFT anyhow)
                 result = matvec_toeplitz_upper_triangular(src_coeff_exprs,
                     derivatives)
                 result = self.m2l_postprocess_local_exprs(src_expansion,

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -538,6 +538,8 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
             else:
                 src_coeff_exprs = self.m2l_preprocess_multipole_exprs(src_expansion,
                         src_coeff_exprs, sac, src_rscale)
+                # Returns a big symbolic sum of matrix entries
+                # (FIXME? Though this is just the correctness-checking fallback for the FFT anyhow)
                 result = matvec_toeplitz_upper_triangular(src_coeff_exprs,
                     derivatives)
                 result = self.m2l_postprocess_local_exprs(src_expansion,

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -537,14 +537,18 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
                 assert len(src_coeff_exprs) == len(derivatives)
                 result = [a*b for a, b in zip(derivatives, src_coeff_exprs)]
             else:
-                src_coeff_exprs = self.m2l_preprocess_multipole_exprs(src_expansion,
-                        src_coeff_exprs, sac, src_rscale)
+                if not self.use_preprocessing_for_m2l:
+                    src_coeff_exprs = self.m2l_preprocess_multipole_exprs(
+                        src_expansion, src_coeff_exprs, sac, src_rscale)
+
                 # Returns a big symbolic sum of matrix entries
                 # (FIXME? Though this is just the correctness-checking
                 # fallback for the FFT anyhow)
                 result = matvec_toeplitz_upper_triangular(src_coeff_exprs,
                     derivatives)
-                result = self.m2l_postprocess_local_exprs(src_expansion,
+
+                if not self.use_preprocessing_for_m2l:
+                    result = self.m2l_postprocess_local_exprs(src_expansion,
                         result, src_rscale, tgt_rscale, sac)
 
             logger.info("building translation operator: done")

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -684,7 +684,7 @@ class VolumeTaylorLocalExpansionBase(LocalExpansionBase):
 
             if self.use_preprocessing_for_m2l:
                 expr = src_coeffs[icoeff_tgt] \
-                        * m2l_translation_classes_dependent_data(icoeff_tgt)
+                        * m2l_translation_classes_dependent_data[icoeff_tgt]
             else:
                 toeplitz_first_row = src_coeffs[icoeff_src-icoeff_tgt]
                 vector = m2l_translation_classes_dependent_data[icoeff_src]

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -1006,7 +1006,9 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                         name="e2e",
                         lang_version=lp.MOST_RECENT_LANGUAGE_VERSION,
                         )
-        raise NotImplementedError("")
+        raise NotImplementedError(
+            f"A direct loopy kernel for translation from "
+            f"{self.src_expansion} to {self.tgt_expansion} is not implemented.")
 
 
 class H2DLocalExpansion(_FourierBesselLocalExpansion):

--- a/sumpy/expansion/local.py
+++ b/sumpy/expansion/local.py
@@ -980,7 +980,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                 translated_coeffs = [a * b for a, b in zip(derivatives,
                     src_coeff_exprs)]
             else:
-                if self.use_preprocessing_for_m2l:
+                if not self.use_preprocessing_for_m2l:
                     src_coeff_exprs = self.m2l_preprocess_multipole_exprs(
                         src_expansion, src_coeff_exprs, sac, src_rscale)
 
@@ -990,7 +990,7 @@ class _FourierBesselLocalExpansion(LocalExpansionBase):
                         for m in src_expansion.get_coefficient_identifiers())
                     for j in self.get_coefficient_identifiers()]
 
-                if self.use_preprocessing_for_m2l:
+                if not self.use_preprocessing_for_m2l:
                     translated_coeffs = self.m2l_postprocess_local_exprs(
                         src_expansion, translated_coeffs, src_rscale, tgt_rscale,
                         sac)

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -90,9 +90,9 @@ class SumpyTreeIndependentDataForWrangler(TreeIndependentDataForWrangler):
         self.use_rscale = use_rscale
         self.strength_usage = strength_usage
         self.use_fft_for_m2l = use_fft_for_m2l
-        if self.use_preprocessing_for_m2l is None:
+        if use_preprocessing_for_m2l is None:
             self.use_preprocessing_for_m2l = use_fft_for_m2l
-        else
+        else:
             self.use_preprocessing_for_m2l = use_preprocessing_for_m2l
 
         super().__init__()
@@ -759,7 +759,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
         queue = mpole_exps.queue
         local_exps = self.local_expansion_zeros(mpole_exps)
 
-        if self.use_preprocessing_for_m2l:
+        if self.tree_indep.use_preprocessing_for_m2l:
             preprocessed_mpole_exps = \
                 self.m2l_preproc_mpole_expansion_zeros(mpole_exps)
             for lev in range(self.tree.nlevels):
@@ -839,7 +839,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
 
         postprocess_evts = []
 
-        if self.use_preprocessing_for_m2l:
+        if self.tree_indep.use_preprocessing_for_m2l:
             for lev in range(self.tree.nlevels):
                 order = self.level_orders[lev]
                 postprocess_local_kernel = \

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -77,6 +77,10 @@ class SumpyTreeIndependentDataForWrangler(TreeIndependentDataForWrangler):
         :arg exclude_self: whether the self contribution should be excluded
         :arg strength_usage: passed unchanged to p2l, p2m and p2p.
         :arg source_kernels: passed unchanged to p2l, p2m and p2p.
+        :arg use_fft_for_m2l: Use an FFT based multipole-to-local expansion.
+        :arg use_preprocessing_for_m2l: do preprocessing of the source multipole
+            expansion and postprocessing of the target local expansion for
+            multipole-to-local expansion.
         """
         self.multipole_expansion_factory = multipole_expansion_factory
         self.local_expansion_factory = local_expansion_factory

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -718,7 +718,6 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
 
             m2l_translation_classes_dependent_data = \
                     m2l_translation_classes_dependent_data.with_queue(None)
-
         return m2l_translation_classes_dependent_data
 
     def _add_m2l_precompute_kwargs(self, kwargs_for_m2l,

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -863,9 +863,9 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
                 )
                 postprocess_evts.append(evt)
 
-        events = preprocess_evts + translate_evts + postprocess_evts
+        timing_events = preprocess_evts + translate_evts + postprocess_evts
 
-        return (local_exps, SumpyTimingFuture(queue, events))
+        return (local_exps, SumpyTimingFuture(queue, timing_events))
 
     def eval_multipoles(self,
             target_boxes_by_source_level, source_boxes_by_level, mpole_exps):

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -67,7 +67,7 @@ class SumpyTreeIndependentDataForWrangler(TreeIndependentDataForWrangler):
             local_expansion_factory,
             target_kernels, exclude_self=False, use_rscale=None,
             strength_usage=None, source_kernels=None,
-            use_preprocessing_for_m2l=False):
+            use_fft_for_m2l=False):
         """
         :arg multipole_expansion_factory: a callable of a single argument (order)
             that returns a multipole expansion.
@@ -85,7 +85,7 @@ class SumpyTreeIndependentDataForWrangler(TreeIndependentDataForWrangler):
         self.exclude_self = exclude_self
         self.use_rscale = use_rscale
         self.strength_usage = strength_usage
-        self.use_preprocessing_for_m2l = use_preprocessing_for_m2l
+        self.use_fft_for_m2l = use_fft_for_m2l
 
         super().__init__()
 
@@ -103,7 +103,7 @@ class SumpyTreeIndependentDataForWrangler(TreeIndependentDataForWrangler):
     @memoize_method
     def local_expansion(self, order):
         return self.local_expansion_factory(order, self.use_rscale,
-                use_preprocessing_for_m2l=self.use_preprocessing_for_m2l)
+                use_fft_for_m2l=self.use_fft_for_m2l)
 
     @memoize_method
     def p2m(self, tgt_order):
@@ -316,7 +316,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
 
         self.dtype = dtype
 
-        if not self.tree_indep.use_preprocessing_for_m2l:
+        if not self.tree_indep.use_fft_for_m2l:
             # If not FFT, we don't need complex dtypes
             self.preprocessed_mpole_dtype = dtype
         elif preprocessed_mpole_dtype is not None:
@@ -351,7 +351,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
         if base_kernel.is_translation_invariant:
             if translation_classes_data is None:
                 from warnings import warn
-                if self.tree_indep.use_preprocessing_for_m2l:
+                if self.tree_indep.use_fft_for_m2l:
                     raise NotImplementedError(
                          "FFT based List 2 (multipole-to-local) translations "
                          "without translation_classes_data argument is not "
@@ -371,7 +371,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
             self.supports_optimized_m2l = False
 
         self.translation_classes_data = translation_classes_data
-        self.use_preprocessing_for_m2l = self.tree_indep.use_preprocessing_for_m2l
+        self.use_fft_for_m2l = self.tree_indep.use_fft_for_m2l
 
     # {{{ data vector utilities
 

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -749,10 +749,13 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
         preprocess_evts = []
         queue = mpole_exps.queue
         local_exps = self.local_expansion_zeros(mpole_exps)
+        preprocessed_mpole_exps = \
+            self.m2l_preproc_mpole_expansion_zeros(mpole_exps)
 
-        if self.supports_optimized_m2l:
-            preprocessed_mpole_exps = \
-                    self.m2l_preproc_mpole_expansion_zeros(mpole_exps)
+        use_preprocessing = self.supports_translation_classes and \
+            preprocessed_mpole_exps.size > 0
+
+        if use_preprocessing:
             for lev in range(self.tree.nlevels):
                 order = self.level_orders[lev]
                 preprocess_mpole_kernel = \
@@ -795,7 +798,8 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
                 continue
 
             order = self.level_orders[lev]
-            m2l = self.tree_indep.m2l(order, order, self.supports_translation_classes)
+            m2l = self.tree_indep.m2l(order, order,
+                    self.supports_translation_classes)
 
             source_level_start_ibox, source_mpoles_view = \
                     mpole_exps_view_func(mpole_exps, lev)
@@ -829,7 +833,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
 
         postprocess_evts = []
 
-        if self.supports_optimized_m2l:
+        if use_preprocessing:
             for lev in range(self.tree.nlevels):
                 order = self.level_orders[lev]
                 postprocess_local_kernel = \

--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -364,11 +364,11 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
                          "to the wrangler for optimized List 2.",
                          SumpyTranslationClassesDataNotSuppliedWarning,
                          stacklevel=2)
-                self.supports_optimized_m2l = False
+                self.supports_translation_classes = False
             else:
-                self.supports_optimized_m2l = True
+                self.supports_translation_classes = True
         else:
-            self.supports_optimized_m2l = False
+            self.supports_translation_classes = False
 
         self.translation_classes_data = translation_classes_data
         self.use_fft_for_m2l = self.tree_indep.use_fft_for_m2l
@@ -726,7 +726,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
         multipole-to-local translation with precomputation to the keywords
         passed to multipole-to-local translation.
         """
-        if not self.supports_optimized_m2l:
+        if not self.supports_translation_classes:
             return
         m2l_translation_classes_dependent_data = \
                 self.multipole_to_local_precompute()
@@ -795,7 +795,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
                 continue
 
             order = self.level_orders[lev]
-            m2l = self.tree_indep.m2l(order, order, self.supports_optimized_m2l)
+            m2l = self.tree_indep.m2l(order, order, self.supports_translation_classes)
 
             source_level_start_ibox, source_mpoles_view = \
                     mpole_exps_view_func(mpole_exps, lev)

--- a/sumpy/p2p.py
+++ b/sumpy/p2p.py
@@ -255,6 +255,15 @@ class P2P(P2PBase):
                 targets_is_obj_array=is_obj_array_like(targets),
                 sources_is_obj_array=is_obj_array_like(sources))
 
+        """
+        knl = lp.add_and_infer_dtypes(knl,
+            {"target_to_source": kwargs["target_to_source"].dtype,
+             "targets": targets[0].dtype,
+             "sources": sources[0].dtype,
+             "strength": strength[0].dtype})
+        print(lp.generate_code_v2(knl).device_code())
+        """
+
         return knl(queue, sources=sources, targets=targets, strength=strength,
                 **kwargs)
 

--- a/sumpy/p2p.py
+++ b/sumpy/p2p.py
@@ -255,15 +255,6 @@ class P2P(P2PBase):
                 targets_is_obj_array=is_obj_array_like(targets),
                 sources_is_obj_array=is_obj_array_like(sources))
 
-        """
-        knl = lp.add_and_infer_dtypes(knl,
-            {"target_to_source": kwargs["target_to_source"].dtype,
-             "targets": targets[0].dtype,
-             "sources": sources[0].dtype,
-             "strength": strength[0].dtype})
-        print(lp.generate_code_v2(knl).device_code())
-        """
-
         return knl(queue, sources=sources, targets=targets, strength=strength,
                 **kwargs)
 

--- a/test/test_fmm.py
+++ b/test/test_fmm.py
@@ -190,7 +190,7 @@ def test_sumpy_fmm(ctx_factory, knl, local_expn_class, mpole_expn_class,
                 ctx,
                 partial(mpole_expn_class, knl),
                 partial(local_expn_class, knl),
-                target_kernels, use_preprocessing_for_m2l=use_fft)
+                target_kernels, use_fft_for_m2l=use_fft)
 
         with warnings.catch_warnings():
             if not optimized_m2l:


### PR DESCRIPTION
This PR makes a few changes
- Split M2L translation + postprocess_local into two kernels
- Call preprocess and postprocess for non FFT expansions as well. (But only when translation classes data is passed)
- Use a direct loopy kernel for M2L translation