### PR TITLE
m2l: add dependencies for inlined e2e kernel

### DIFF
--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -424,8 +424,9 @@ class M2LUsingTranslationClassesDependentData(E2EFromCSR):
                                 {id=read_src_ibox}
                         <> translation_class = \
                                 m2l_translation_classes_lists[isrc_box]
-                        <> translation_class_rel = translation_class - \
-                                                    translation_classes_level_start
+                        <> translation_class_rel = \
+                                translation_class - translation_classes_level_start \
+                                {id=translation_offset}
                         [icoeff_tgt]: coeffs[icoeff_tgt] = e2e(
                             [icoeff_tgt]: coeffs[icoeff_tgt],
                             [icoeff_src]: src_expansions[src_ibox - src_base_ibox,
@@ -465,7 +466,7 @@ class M2LUsingTranslationClassesDependentData(E2EFromCSR):
                         offset=lp.auto),
                     lp.ValueArg("ntranslation_classes, ntranslation_classes_lists",
                         np.int32),
-                    "..."
+                    ...
                 ] + gather_loopy_arguments([self.src_expansion,
                                             self.tgt_expansion]),
                 name=self.name,
@@ -481,6 +482,10 @@ class M2LUsingTranslationClassesDependentData(E2EFromCSR):
 
         loopy_knl = lp.merge([translation_knl, loopy_knl])
         loopy_knl = lp.inline_callable_kernel(loopy_knl, "e2e")
+        loopy_knl = lp.add_dependency(
+                loopy_knl, "id:e2e_insn*", "read_src_ibox")
+        loopy_knl = lp.add_dependency(
+                loopy_knl, "id:e2e_insn*", "translation_offset")
 
         for knl in [self.src_expansion.kernel, self.tgt_expansion.kernel]:
             loopy_knl = knl.prepare_loopy_kernel(loopy_knl)


### PR DESCRIPTION
This was generating a lot of warnings like
```
loopy/kernel/creation.py:1911: LoopyWarning: in kernel m2l_using_translation_classes_dependent_data: 
The single-writer dependency heuristic added dependencies on instruction ID(s)
'read_src_ibox, translation_offset' to instruction ID 'e2e_insn_3' after
kernel creation is complete. This is deprecated and may stop working in the
future. To fix this, ensure that instruction dependencies are added/resolved 
as soon as possible, ideally at kernel creation time. (add 
'single_writer_after_creation' to silenced_warnings kernel attribute to disable)
```

Not sure if this is the right way to add the required dependencies, so better suggestions welcome!