### PR TITLE
Drop Conda version constraint for symengine

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -12,6 +12,6 @@ dependencies:
 - islpy
 - pyopencl
 - python=3
-- python-symengine=0.6.0
+- python-symengine
 - pyfmmlib
 - pyrsistent


### PR DESCRIPTION
This forced CI onto Py3.8, as far as I can tell, which may have contributed to a CI failure that I'm not sure I fully understand:

https://gitlab.tiker.net/inducer/sumpy/-/jobs/425789