### PR TITLE
Fix order in events for AggregateProfilingEvent

### DIFF
--- a/sumpy/fmm.py
+++ b/sumpy/fmm.py
@@ -890,7 +890,7 @@ class SumpyExpansionWrangler(ExpansionWranglerInterface):
                 )
 
                 if self.tree_indep.m2l_translation.use_fft:
-                    postprocess_evts.append(AggregateProfilingEvent([evt, evt_fft]))
+                    postprocess_evts.append(AggregateProfilingEvent([evt_fft, evt]))
                 else:
                     postprocess_evts.append(evt)
 


### PR DESCRIPTION
AggregateProfilingEvent assumes that the last event depends on all the others.

Fixes https://github.com/inducer/sumpy/issues/127