### PR TITLE
Disable global barrier check in m2l preprocess

### DIFF
--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -696,6 +696,13 @@ class M2LPreprocessMultipole(E2EBase):
         loopy_knl = lp.merge([loopy_knl, single_box_preprocess_knl])
         loopy_knl = lp.inline_callable_kernel(loopy_knl, "m2l_preprocess_inner")
 
+        loopy_knl = lp.set_options(loopy_knl,
+                enforce_variable_access_ordered="no_check",
+                # FIXME: Without this, Loopy spends an eternity checking
+                # scattered writes to global variables to see whether barriers
+                # need to be inserted.
+                disable_global_barriers=True)
+
         return loopy_knl
 
     def get_optimized_kernel(self, result_dtype):


### PR DESCRIPTION
Here's another one similar to #132.

cc @isuruf @alexfikl 