### PR TITLE
Add pylint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
                 curl -L -O https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-flake8.sh
                 . ./prepare-and-run-flake8.sh "$(basename $GITHUB_REPOSITORY)" test examples benchmarks
 
+    pylint:
+        name: Pylint
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: actions/checkout@v2
+        -   name: "Main Script"
+            run: |
+                USE_CONDA_BUILD=1
+                EXTRA_INSTALL="pyvisfile scipy matplotlib"
+                curl -L -O https://tiker.net/ci-support-v0
+                . ci-support-v0
+                build_py_project
+                run_pylint "$(basename $GITHUB_REPOSITORY)" test/test_*.py
+
     docs:
         name: Documentation
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
                 build_py_project
-                run_pylint "$(basename $GITHUB_REPOSITORY)" test/test_*.py
+                run_pylint "$(basename $GITHUB_REPOSITORY)" examples/*.py, test/*.py
 
     docs:
         name: Documentation
@@ -86,7 +86,6 @@ jobs:
                 EXTRA_INSTALL="pyvisfile scipy"
                 build_py_project_in_conda_env
                 run_examples
-
 
     downstream_tests:
         strategy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,6 +134,7 @@ Pylint:
   - curl -L -O https://tiker.net/ci-support-v0
   - . ci-support-v0
   - build_py_project
+  - run_pylint "$(basename $GITHUB_REPOSITORY)" examples/*.py, test/*.py
   tags:
   - python3
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,6 +128,17 @@ Flake8:
   except:
   - tags
 
+Pylint:
+  script:
+  - EXTRA_INSTALL="pybind11 numpy mako scipy matplotlib pyvisfile mpi4py"
+  - curl -L -O https://tiker.net/ci-support-v0
+  - . ci-support-v0
+  - build_py_project
+  tags:
+  - python3
+  except:
+  - tags
+
 Benchmarks:
   stage: test
   script: |

--- a/.pylintrc-local.yml
+++ b/.pylintrc-local.yml
@@ -1,0 +1,2 @@
+- arg: extension-pkg-whitelist
+  val: mayavi

--- a/examples/curve-pot.py
+++ b/examples/curve-pot.py
@@ -25,11 +25,11 @@ def process_kernel(knl, what_operator):
     if what_operator == "S":
         pass
     elif what_operator == "S0":
-        from sumpy.kernel import TargetDerivative
-        target_knl = TargetDerivative(0, knl)
+        from sumpy.kernel import AxisTargetDerivative
+        target_knl = AxisTargetDerivative(0, knl)
     elif what_operator == "S1":
-        from sumpy.kernel import TargetDerivative
-        target_knl = TargetDerivative(1, knl)
+        from sumpy.kernel import AxisTargetDerivative
+        target_knl = AxisTargetDerivative(1, knl)
     elif what_operator == "D":
         from sumpy.kernel import DirectionalSourceDerivative
         source_knl = DirectionalSourceDerivative(knl)

--- a/sumpy/codegen.py
+++ b/sumpy/codegen.py
@@ -667,8 +667,6 @@ def to_loopy_insns(assignments, vector_names=frozenset(), pymbolic_expr_maps=(),
     bik = BigIntegerKiller()
     cmr = ComplexRewriter(complex_dtype)
 
-    cmb_mapper = combine_mappers(bdr, btog, vcr, pwr, ssg, bik, cmr)
-
     if 0:
         # https://github.com/inducer/sumpy/pull/40#issuecomment-852635444
         cmb_mapper = combine_mappers(bdr, btog, vcr, pwr, ssg, bik, cmr)

--- a/sumpy/e2e.py
+++ b/sumpy/e2e.py
@@ -26,7 +26,7 @@ import sumpy.symbolic as sym
 import pymbolic
 
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
-from sumpy.tools import KernelCacheWrapper, to_complex_dtype
+from sumpy.tools import KernelCacheMixin, to_complex_dtype
 from pytools import memoize_method
 
 import logging
@@ -48,7 +48,9 @@ Expansion-to-expansion
 
 # {{{ translation base class
 
-class E2EBase(KernelCacheWrapper):
+class E2EBase(KernelCacheMixin):
+    default_name = "e2e"
+
     def __init__(self, ctx, src_expansion, tgt_expansion,
             name=None, device=None):
         """
@@ -129,6 +131,9 @@ class E2EBase(KernelCacheWrapper):
                 self.src_expansion,
                 self.tgt_expansion,
         )
+
+    def get_kernel(self):
+        raise NotImplementedError
 
     def get_optimized_kernel(self):
         # FIXME

--- a/sumpy/e2p.py
+++ b/sumpy/e2p.py
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from abc import ABC, abstractmethod
+
 import numpy as np
 import loopy as lp
 import sumpy.symbolic as sym
@@ -42,9 +44,7 @@ Expansion-to-particle
 
 # {{{ E2P base class
 
-class E2PBase(KernelCacheMixin):
-    default_name = "e2p"
-
+class E2PBase(KernelCacheMixin, ABC):
     def __init__(self, ctx, expansion, kernels,
             name=None, device=None):
         """
@@ -76,6 +76,11 @@ class E2PBase(KernelCacheMixin):
         self.device = device
 
         self.dim = expansion.dim
+
+    @property
+    @abstractmethod
+    def default_name(self):
+        pass
 
     def get_loopy_insns_and_result_names(self):
         from sumpy.symbolic import make_sym_vector
@@ -132,7 +137,9 @@ class E2PBase(KernelCacheMixin):
 # {{{ E2P to single box (L2P, likely)
 
 class E2PFromSingleBox(E2PBase):
-    default_name = "e2p_from_single_box"
+    @property
+    def default_name(self):
+        return "e2p_from_single_box"
 
     def get_kernel(self):
         ncoeffs = len(self.expansion)
@@ -234,7 +241,9 @@ class E2PFromSingleBox(E2PBase):
 # {{{ E2P from CSR-like interaction list
 
 class E2PFromCSR(E2PBase):
-    default_name = "e2p_from_csr"
+    @property
+    def default_name(self):
+        return "e2p_from_csr"
 
     def get_kernel(self):
         ncoeffs = len(self.expansion)

--- a/sumpy/e2p.py
+++ b/sumpy/e2p.py
@@ -24,7 +24,7 @@ import numpy as np
 import loopy as lp
 import sumpy.symbolic as sym
 
-from sumpy.tools import KernelCacheWrapper
+from sumpy.tools import KernelCacheMixin
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
 
 
@@ -42,7 +42,9 @@ Expansion-to-particle
 
 # {{{ E2P base class
 
-class E2PBase(KernelCacheWrapper):
+class E2PBase(KernelCacheMixin):
+    default_name = "e2p"
+
     def __init__(self, ctx, expansion, kernels,
             name=None, device=None):
         """

--- a/sumpy/expansion/__init__.py
+++ b/sumpy/expansion/__init__.py
@@ -20,14 +20,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import logging
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Dict, Hashable, List, Tuple, Type
+
 from pytools import memoize_method
+
 import sumpy.symbolic as sym
 from sumpy.tools import add_mi
-from typing import List, Tuple
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 __doc__ = """
 .. autoclass:: ExpansionBase
+
+Expansion Wranglers
+^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: ExpansionTermsWrangler
+.. autoclass:: FullExpansionTermsWrangler
 .. autoclass:: LinearPDEBasedExpansionTermsWrangler
 
 Expansion Factories
@@ -38,18 +50,24 @@ Expansion Factories
 .. autoclass:: VolumeTaylorExpansionFactory
 """
 
-logger = logging.getLogger(__name__)
 
+# {{{ expansion base
 
-# {{{ base class
-
-class ExpansionBase:
+class ExpansionBase(ABC):
     """
-    .. automethod:: with_kernel
-    .. automethod:: __len__
+    .. attribute:: kernel
+    .. attribute:: order
+    .. attribute:: use_rscale
+
     .. automethod:: get_coefficient_identifiers
     .. automethod:: coefficients_from_source
-    .. automethod:: translate_from
+    .. automethod:: coefficients_from_source_vec
+    .. automethod:: evaluate
+
+    .. automethod:: with_kernel
+    .. automethod:: copy
+
+    .. automethod:: __len__
     .. automethod:: __eq__
     .. automethod:: __ne__
     """
@@ -95,18 +113,15 @@ class ExpansionBase:
 
     # }}}
 
-    def with_kernel(self, kernel):
-        return type(self)(kernel, self.order, self.use_rscale)
+    # {{{ abstract interface
 
-    def __len__(self):
-        return len(self.get_coefficient_identifiers())
-
+    @abstractmethod
     def get_coefficient_identifiers(self):
         """
-        Returns the identifiers of the coefficients that actually get stored.
+        :returns: the identifiers of the coefficients that actually get stored.
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def coefficients_from_source(self, kernel, avec, bvec, rscale, sac=None):
         """Form an expansion from a source point.
 
@@ -119,10 +134,9 @@ class ExpansionBase:
         :returns: a list of :mod:`sympy` expressions representing
             the coefficients of the expansion.
         """
-        raise NotImplementedError
 
-    def coefficients_from_source_vec(self, kernels, avec, bvec, rscale, weights,
-            sac=None):
+    def coefficients_from_source_vec(self,
+            kernels, avec, bvec, rscale, weights, sac=None):
         """Form an expansion with a linear combination of kernels and weights.
 
         :arg avec: vector from source to center.
@@ -141,34 +155,20 @@ class ExpansionBase:
                 result[i] += weight * coeffs[i]
         return result
 
+    @abstractmethod
     def evaluate(self, kernel, coeffs, bvec, rscale, sac=None):
         """
-        :return: a :mod:`sympy` expression corresponding
+        :returns: a :mod:`sympy` expression corresponding
             to the evaluated expansion with the coefficients
             in *coeffs*.
         """
 
-        raise NotImplementedError
+    # }}}
 
-    def translate_from(self, src_expansion, src_coeff_exprs, src_rscale,
-            dvec, tgt_rscale, sac=None):
-        raise NotImplementedError
+    # {{{ copy
 
-    def update_persistent_hash(self, key_hash, key_builder):
-        key_hash.update(type(self).__name__.encode("utf8"))
-        key_builder.rec(key_hash, self.kernel)
-        key_builder.rec(key_hash, self.order)
-        key_builder.rec(key_hash, self.use_rscale)
-
-    def __eq__(self, other):
-        return (
-                type(self) == type(other)
-                and self.kernel == other.kernel
-                and self.order == other.order
-                and self.use_rscale == other.use_rscale)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    def with_kernel(self, kernel):
+        return type(self)(kernel, self.order, self.use_rscale)
 
     def copy(self, **kwargs):
         new_kwargs = {
@@ -184,14 +184,44 @@ class ExpansionBase:
 
         return type(self)(**new_kwargs)
 
+    # }}}
+
+    def update_persistent_hash(self, key_hash, key_builder):
+        key_hash.update(type(self).__name__.encode("utf8"))
+        key_builder.rec(key_hash, self.kernel)
+        key_builder.rec(key_hash, self.order)
+        key_builder.rec(key_hash, self.use_rscale)
+
+    def __len__(self):
+        return len(self.get_coefficient_identifiers())
+
+    def __eq__(self, other):
+        return (
+                type(self) == type(other)
+                and self.kernel == other.kernel
+                and self.order == other.order
+                and self.use_rscale == other.use_rscale)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 # }}}
 
 
 # {{{ expansion terms wrangler
 
-class ExpansionTermsWrangler:
+class ExpansionTermsWrangler(ABC):
+    """
+    .. attribute:: order
+    .. attribute:: dim
+    .. attribute:: max_mi
 
+    .. automethod:: get_coefficient_identifiers
+    .. automethod:: get_full_kernel_derivatives_from_stored
+    .. automethod:: get_stored_mpole_coefficients_from_full
+
+    .. automethod:: get_full_coefficient_identifiers
+    """
     init_arg_names = ("order", "dim", "max_mi")
 
     def __init__(self, order, dim, max_mi=None):
@@ -199,16 +229,23 @@ class ExpansionTermsWrangler:
         self.dim = dim
         self.max_mi = max_mi
 
+    # {{{ abstract interface
+
+    @abstractmethod
     def get_coefficient_identifiers(self):
-        raise NotImplementedError
+        pass
 
-    def get_full_kernel_derivatives_from_stored(self, stored_kernel_derivatives,
-            rscale, sac=None):
-        raise NotImplementedError
+    @abstractmethod
+    def get_full_kernel_derivatives_from_stored(self,
+            stored_kernel_derivatives, rscale, sac=None):
+        pass
 
-    def get_stored_mpole_coefficients_from_full(self, full_mpole_coefficients,
-            rscale, sac=None):
-        raise NotImplementedError
+    @abstractmethod
+    def get_stored_mpole_coefficients_from_full(self,
+            full_mpole_coefficients, rscale, sac=None):
+        pass
+
+    # }}}
 
     @memoize_method
     def get_full_coefficient_identifiers(self):
@@ -240,6 +277,8 @@ class ExpansionTermsWrangler:
                 "unexpected keyword arguments '{}'".format(", ".join(kwargs)))
 
         return type(self)(**new_kwargs)
+
+    # {{{ hyperplane helpers
 
     def _get_mi_hyperpplanes(self) -> List[Tuple[int, int]]:
         r"""
@@ -303,18 +342,23 @@ class ExpansionTermsWrangler:
 
         return res
 
+    # }}}
+
 
 class FullExpansionTermsWrangler(ExpansionTermsWrangler):
+    def get_coefficient_identifiers(self):
+        return super().get_full_coefficient_identifiers()
 
-    get_coefficient_identifiers = (
-            ExpansionTermsWrangler.get_full_coefficient_identifiers)
-
-    def get_full_kernel_derivatives_from_stored(self, stored_kernel_derivatives,
-            rscale, sac=None):
+    def get_full_kernel_derivatives_from_stored(self,
+            stored_kernel_derivatives, rscale, sac=None):
         return stored_kernel_derivatives
 
-    get_stored_mpole_coefficients_from_full = (
-            get_full_kernel_derivatives_from_stored)
+    def get_stored_mpole_coefficients_from_full(self,
+            full_mpole_coefficients, rscale, sac=None):
+        return self.get_full_kernel_derivatives_from_stored(
+            full_mpole_coefficients, rscale, sac=sac)
+
+# }}}
 
 
 # {{{ sparse matrix-vector multiplication
@@ -392,6 +436,8 @@ class CSEMatVecOperator:
 # }}}
 
 
+# {{{ LinearPDEBasedExpansionTermsWrangler
+
 class LinearPDEBasedExpansionTermsWrangler(ExpansionTermsWrangler):
     """
     .. automethod:: __init__
@@ -411,18 +457,18 @@ class LinearPDEBasedExpansionTermsWrangler(ExpansionTermsWrangler):
     def get_coefficient_identifiers(self):
         return self.stored_identifiers
 
-    def get_full_kernel_derivatives_from_stored(self, stored_kernel_derivatives,
-            rscale, sac=None):
-
+    def get_full_kernel_derivatives_from_stored(self,
+            stored_kernel_derivatives, rscale, sac=None):
         from sumpy.tools import add_to_sac
+
         projection_matrix = self.get_projection_matrix(rscale)
         return projection_matrix.matvec(stored_kernel_derivatives,
                 lambda x: add_to_sac(sac, x))
 
-    def get_stored_mpole_coefficients_from_full(self, full_mpole_coefficients,
-            rscale, sac=None):
-
+    def get_stored_mpole_coefficients_from_full(self,
+            full_mpole_coefficients, rscale, sac=None):
         from sumpy.tools import add_to_sac
+
         projection_matrix = self.get_projection_matrix(rscale)
         return projection_matrix.transpose_matvec(full_mpole_coefficients,
                 lambda x: add_to_sac(sac, x))
@@ -636,9 +682,13 @@ class LinearPDEBasedExpansionTermsWrangler(ExpansionTermsWrangler):
 # }}}
 
 
-# {{{ volume taylor
+# {{{ volume taylor expansion
 
-class VolumeTaylorExpansionBase:
+# FIXME: This is called an expansion but doesn't inherit from ExpansionBase?
+
+class VolumeTaylorExpansionMixin:
+    expansion_terms_wrangler_class: ClassVar[Type[ExpansionTermsWrangler]]
+    expansion_terms_wrangler_cache: ClassVar[Dict[Hashable, Any]] = {}
 
     @classmethod
     def get_or_make_expansion_terms_wrangler(cls, *key):
@@ -679,20 +729,16 @@ class VolumeTaylorExpansionBase:
         return self._storage_loc_dict[i]
 
 
-class VolumeTaylorExpansion(VolumeTaylorExpansionBase):
-
+class VolumeTaylorExpansion(VolumeTaylorExpansionMixin):
     expansion_terms_wrangler_class = FullExpansionTermsWrangler
-    expansion_terms_wrangler_cache = {}
 
     # not user-facing, be strict about having to pass use_rscale
     def __init__(self, kernel, order, use_rscale):
         self.expansion_terms_wrangler_key = (order, kernel.dim)
 
 
-class LinearPDEConformingVolumeTaylorExpansion(VolumeTaylorExpansionBase):
-
+class LinearPDEConformingVolumeTaylorExpansion(VolumeTaylorExpansionMixin):
     expansion_terms_wrangler_class = LinearPDEBasedExpansionTermsWrangler
-    expansion_terms_wrangler_cache = {}
 
     # not user-facing, be strict about having to pass use_rscale
     def __init__(self, kernel, order, use_rscale):
@@ -736,21 +782,23 @@ class BiharmonicConformingVolumeTaylorExpansion(
 
 # {{{ expansion factory
 
-class ExpansionFactoryBase:
-    """An interface
+class ExpansionFactoryBase(ABC):
+    """
     .. automethod:: get_local_expansion_class
     .. automethod:: get_multipole_expansion_class
     """
 
+    @abstractmethod
     def get_local_expansion_class(self, base_kernel):
-        """Returns a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
         """
-        raise NotImplementedError()
+        :returns: a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
+        """
 
+    @abstractmethod
     def get_multipole_expansion_class(self, base_kernel):
-        """Returns a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
         """
-        raise NotImplementedError()
+        :returns: a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
+        """
 
 
 class VolumeTaylorExpansionFactory(ExpansionFactoryBase):
@@ -759,13 +807,15 @@ class VolumeTaylorExpansionFactory(ExpansionFactoryBase):
     """
 
     def get_local_expansion_class(self, base_kernel):
-        """Returns a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
+        """
+        :returns: a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
         """
         from sumpy.expansion.local import VolumeTaylorLocalExpansion
         return VolumeTaylorLocalExpansion
 
     def get_multipole_expansion_class(self, base_kernel):
-        """Returns a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
+        """
+        :returns: a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
         """
         from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion
         return VolumeTaylorMultipoleExpansion
@@ -777,7 +827,8 @@ class DefaultExpansionFactory(ExpansionFactoryBase):
     """
 
     def get_local_expansion_class(self, base_kernel):
-        """Returns a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
+        """
+        :returns: a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
         """
         from sumpy.expansion.local import (
                 LinearPDEConformingVolumeTaylorLocalExpansion,
@@ -789,7 +840,8 @@ class DefaultExpansionFactory(ExpansionFactoryBase):
             return VolumeTaylorLocalExpansion
 
     def get_multipole_expansion_class(self, base_kernel):
-        """Returns a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
+        """
+        :returns: a subclass of :class:`ExpansionBase` suitable for *base_kernel*.
         """
         from sumpy.expansion.multipole import (
                 LinearPDEConformingVolumeTaylorMultipoleExpansion,

--- a/sumpy/expansion/multipole.py
+++ b/sumpy/expansion/multipole.py
@@ -21,10 +21,14 @@ THE SOFTWARE.
 """
 
 import math
+from abc import abstractmethod
 
 import sumpy.symbolic as sym
 from sumpy.expansion import (
-    ExpansionBase, VolumeTaylorExpansion, LinearPDEConformingVolumeTaylorExpansion)
+    ExpansionBase,
+    VolumeTaylorExpansion,
+    VolumeTaylorExpansionMixin,
+    LinearPDEConformingVolumeTaylorExpansion)
 from sumpy.tools import mi_set_axis, add_to_sac, mi_power, mi_factorial
 
 import logging
@@ -46,7 +50,8 @@ class MultipoleExpansionBase(ExpansionBase):
 
 # {{{ volume taylor
 
-class VolumeTaylorMultipoleExpansionBase(MultipoleExpansionBase):
+class VolumeTaylorMultipoleExpansionBase(
+        VolumeTaylorExpansionMixin, MultipoleExpansionBase):
     """
     Coefficients represent the terms in front of the kernel derivatives.
     """
@@ -396,6 +401,10 @@ class BiharmonicConformingVolumeTaylorMultipoleExpansion(
 # {{{ 2D Hankel-based expansions
 
 class _HankelBased2DMultipoleExpansion(MultipoleExpansionBase):
+    @abstractmethod
+    def get_bessel_arg_scaling(self):
+        return
+
     def get_storage_index(self, k):
         return self.order+k
 

--- a/sumpy/p2e.py
+++ b/sumpy/p2e.py
@@ -49,8 +49,6 @@ class P2EBase(KernelCacheMixin, KernelComputation):
     .. automethod:: __init__
     """
 
-    default_name = "p2e"
-
     def __init__(self, ctx, expansion, kernels=None,
             name=None, device=None, strength_usage=None):
         """
@@ -124,9 +122,6 @@ class P2EBase(KernelCacheMixin, KernelComputation):
         return (type(self).__name__, self.name, self.expansion,
                 tuple(self.source_kernels), tuple(self.strength_usage))
 
-    def get_kernel(self):
-        raise NotImplementedError
-
     def get_optimized_kernel(self, sources_is_obj_array, centers_is_obj_array):
         knl = self.get_kernel()
 
@@ -165,7 +160,9 @@ class P2EFromSingleBox(P2EBase):
     .. automethod:: __call__
     """
 
-    default_name = "p2e_from_single_box"
+    @property
+    def default_name(self):
+        return "p2e_from_single_box"
 
     def get_kernel(self):
         ncoeffs = len(self.expansion)
@@ -267,7 +264,9 @@ class P2EFromCSR(P2EBase):
     .. automethod:: __call__
     """
 
-    default_name = "p2e_from_csr"
+    @property
+    def default_name(self):
+        return "p2e_from_csr"
 
     def get_kernel(self):
         ncoeffs = len(self.expansion)

--- a/sumpy/p2e.py
+++ b/sumpy/p2e.py
@@ -24,7 +24,7 @@ import numpy as np
 import loopy as lp
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
 
-from sumpy.tools import KernelCacheWrapper, KernelComputation
+from sumpy.tools import KernelCacheMixin, KernelComputation
 
 import logging
 logger = logging.getLogger(__name__)
@@ -43,11 +43,13 @@ Particle-to-Expansion
 
 # {{{ P2E base class
 
-class P2EBase(KernelComputation, KernelCacheWrapper):
+class P2EBase(KernelCacheMixin, KernelComputation):
     """Common input processing for kernel computations.
 
     .. automethod:: __init__
     """
+
+    default_name = "p2e"
 
     def __init__(self, ctx, expansion, kernels=None,
             name=None, device=None, strength_usage=None):
@@ -121,6 +123,9 @@ class P2EBase(KernelComputation, KernelCacheWrapper):
     def get_cache_key(self):
         return (type(self).__name__, self.name, self.expansion,
                 tuple(self.source_kernels), tuple(self.strength_usage))
+
+    def get_kernel(self):
+        raise NotImplementedError
 
     def get_optimized_kernel(self, sources_is_obj_array, centers_is_obj_array):
         knl = self.get_kernel()

--- a/sumpy/p2p.py
+++ b/sumpy/p2p.py
@@ -28,7 +28,7 @@ import loopy as lp
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
 
 from sumpy.tools import (
-        KernelComputation, KernelCacheWrapper, is_obj_array_like)
+        KernelComputation, KernelCacheMixin, is_obj_array_like)
 
 
 __doc__ = """
@@ -50,7 +50,9 @@ Particle-to-particle
 
 # {{{ p2p base class
 
-class P2PBase(KernelComputation, KernelCacheWrapper):
+class P2PBase(KernelCacheMixin, KernelComputation):
+    default_name = "p2p"
+
     def __init__(self, ctx, target_kernels, exclude_self, strength_usage=None,
             value_dtypes=None, name=None, device=None, source_kernels=None):
         """

--- a/sumpy/p2p.py
+++ b/sumpy/p2p.py
@@ -51,8 +51,6 @@ Particle-to-particle
 # {{{ p2p base class
 
 class P2PBase(KernelCacheMixin, KernelComputation):
-    default_name = "p2p"
-
     def __init__(self, ctx, target_kernels, exclude_self, strength_usage=None,
             value_dtypes=None, name=None, device=None, source_kernels=None):
         """
@@ -175,9 +173,6 @@ class P2PBase(KernelCacheMixin, KernelComputation):
                     if self.exclude_self else [])
                 + gather_loopy_source_arguments(self.source_kernels))
 
-    def get_kernel(self):
-        raise NotImplementedError
-
     def get_optimized_kernel(self, targets_is_obj_array, sources_is_obj_array):
         # FIXME
         knl = self.get_kernel()
@@ -203,7 +198,9 @@ class P2PBase(KernelCacheMixin, KernelComputation):
 class P2P(P2PBase):
     """Direct applier for P2P interactions."""
 
-    default_name = "p2p_apply"
+    @property
+    def default_name(self):
+        return "p2p_apply"
 
     def get_kernel(self):
         loopy_insns, result_names = self.get_loopy_insns_and_result_names()
@@ -268,7 +265,9 @@ class P2P(P2PBase):
 class P2PMatrixGenerator(P2PBase):
     """Generator for P2P interaction matrix entries."""
 
-    default_name = "p2p_matrix"
+    @property
+    def default_name(self):
+        return "p2p_matrix"
 
     def get_strength_or_not(self, isrc, kernel_idx):
         return 1
@@ -333,7 +332,9 @@ class P2PMatrixSubsetGenerator(P2PBase):
     .. automethod:: __call__
     """
 
-    default_name = "p2p_subset"
+    @property
+    def default_name(self):
+        return "p2p_subset"
 
     def get_strength_or_not(self, isrc, kernel_idx):
         return 1
@@ -438,7 +439,9 @@ class P2PMatrixSubsetGenerator(P2PBase):
 # {{{ P2P from CSR-like interaction list
 
 class P2PFromCSR(P2PBase):
-    default_name = "p2p_from_csr"
+    @property
+    def default_name(self):
+        return "p2p_from_csr"
 
     def get_kernel(self, max_nsources_in_one_box, max_ntargets_in_one_box,
             gpu=False, nsplit=32):

--- a/sumpy/point_calculus.py
+++ b/sumpy/point_calculus.py
@@ -120,7 +120,7 @@ class CalculusPatch:
         """
 
         from pytools import indices_in_shape
-        from scipy.special import eval_chebyt
+        from scipy.special import eval_chebyt   # pylint: disable=no-name-in-module
 
         def eval_basis(ind, x):
             result = 1
@@ -240,8 +240,10 @@ class CalculusPatch:
         :returns: a scalar.
         """
         f_values = f_values.reshape(*self._pshape)
+        zero_eval_vec_1d = self._zero_eval_vec_1d
+
         for _ in range(self.dim):
-            f_values = self._zero_eval_vec_1d.dot(f_values)
+            f_values = zero_eval_vec_1d @ f_values
 
         return f_values
 

--- a/sumpy/qbx.py
+++ b/sumpy/qbx.py
@@ -67,8 +67,6 @@ def stringify_expn_index(i):
 # {{{ base class
 
 class LayerPotentialBase(KernelCacheMixin, KernelComputation):
-    default_name = "qbx"
-
     def __init__(self, ctx, expansion, strength_usage=None,
             value_dtypes=None, name=None, device=None,
             source_kernels=None, target_kernels=None):
@@ -229,7 +227,9 @@ class LayerPotential(LayerPotentialBase):
     .. automethod:: __call__
     """
 
-    default_name = "qbx_apply"
+    @property
+    def default_name(self):
+        return "qbx_apply"
 
     @memoize_method
     def get_kernel(self):
@@ -307,7 +307,9 @@ class LayerPotential(LayerPotentialBase):
 class LayerPotentialMatrixGenerator(LayerPotentialBase):
     """Generator for layer potential matrix entries."""
 
-    default_name = "qbx_matrix"
+    @property
+    def default_name(self):
+        return "qbx_matrix"
 
     def get_strength_or_not(self, isrc, kernel_idx):
         return 1
@@ -376,7 +378,9 @@ class LayerPotentialMatrixSubsetGenerator(LayerPotentialBase):
     .. automethod:: __call__
     """
 
-    default_name = "qbx_subset"
+    @property
+    def default_name(self):
+        return "qbx_subset"
 
     def get_strength_or_not(self, isrc, kernel_idx):
         return 1

--- a/sumpy/qbx.py
+++ b/sumpy/qbx.py
@@ -32,7 +32,7 @@ from pytools import memoize_method
 from pymbolic import parse, var
 
 from sumpy.tools import (
-        KernelComputation, KernelCacheWrapper, is_obj_array_like)
+        KernelComputation, KernelCacheMixin, is_obj_array_like)
 
 import logging
 logger = logging.getLogger(__name__)
@@ -66,7 +66,9 @@ def stringify_expn_index(i):
 
 # {{{ base class
 
-class LayerPotentialBase(KernelComputation, KernelCacheWrapper):
+class LayerPotentialBase(KernelCacheMixin, KernelComputation):
+    default_name = "qbx"
+
     def __init__(self, ctx, expansion, strength_usage=None,
             value_dtypes=None, name=None, device=None,
             source_kernels=None, target_kernels=None):

--- a/sumpy/toys.py
+++ b/sumpy/toys.py
@@ -697,7 +697,7 @@ class SchematicVisitor:
             elif expn_style == "circle":
                 draw_circle(psource.center, psource.radius, fill=None)
             else:
-                raise ValueError(f"unknown expn_style: {self.expn_style}")
+                raise ValueError(f"unknown expn_style: {expn_style}")
 
         if psource.derived_from is None:
             return

--- a/sumpy/visualization.py
+++ b/sumpy/visualization.py
@@ -141,7 +141,7 @@ class FieldPlotter:
 
         if max_val is not None:
             squeezed_fld[squeezed_fld > max_val] = max_val
-            squeezed_fld[squeezed_fld < -max_val] = -max_val
+            squeezed_fld[squeezed_fld < -max_val] = -max_val  # pylint: disable=E1130
 
         squeezed_fld = squeezed_fld[..., ::-1]
 
@@ -165,7 +165,8 @@ class FieldPlotter:
     def show_vector_in_mayavi(self, fld, do_show=True, **kwargs):
         c = self.points
 
-        from mayavi import mlab
+        from mayavi import mlab     # pylint: disable=import-error
+
         mlab.quiver3d(c[0], c[1], c[2], fld[0], fld[1], fld[2],
                 **kwargs)
 
@@ -181,7 +182,7 @@ class FieldPlotter:
     def show_scalar_in_mayavi(self, fld, max_val=None, **kwargs):
         if max_val is not None:
             fld[fld > max_val] = max_val
-            fld[fld < -max_val] = -max_val
+            fld[fld < -max_val] = -max_val  # pylint: disable=E1130
 
         if len(fld.shape) == 1:
             fld = fld.reshape(self.nd_points.shape[1:])
@@ -189,7 +190,7 @@ class FieldPlotter:
         nd_points = self.nd_points.squeeze()[self._get_nontrivial_dims()]
         squeezed_fld = fld.squeeze()
 
-        from mayavi import mlab
+        from mayavi import mlab     # pylint: disable=import-error
         mlab.surf(nd_points[0], nd_points[1], squeezed_fld, **kwargs)
 
 # vim: foldmethod=marker


### PR DESCRIPTION
Wanted to run pylint on #139 to root out some issues a bit faster and noticed that it's not on the CI and it has quite a few errors. This should hopefully fix those. 

Most of the issues were in `sumpy.expansions` because some base classes were using methods and attributes from subclasses. Moved some stuff non-trivially to fix that, so it probably needs a more serious look.