### PR TITLE
Use Sphinx 1+ syntax for mapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,16 +16,16 @@ version = ".".join(str(x) for x in ver_dic["VERSION"])
 release = ver_dic["VERSION_TEXT"]
 
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
-    "https://numpy.org/doc/stable/": None,
-    "https://documen.tician.de/modepy/": None,
-    "https://documen.tician.de/pyopencl/": None,
-    "https://documen.tician.de/pymbolic/": None,
-    "https://documen.tician.de/loopy/": None,
-    "https://documen.tician.de/pytential/": None,
-    "https://documen.tician.de/boxtree/": None,
-    "https://docs.sympy.org/latest/": None,
-    "https://matplotlib.org/stable/": None,
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "modepy": ("https://documen.tician.de/modepy/", None),
+    "pyopencl": ("https://documen.tician.de/pyopencl/", None),
+    "pymbolic": ("https://documen.tician.de/pymbolic/", None),
+    "loopy": ("https://documen.tician.de/loopy/", None),
+    "pytential": ("https://documen.tician.de/pytential/", None),
+    "boxtree": ("https://documen.tician.de/boxtree/", None),
+    "sympy": ("https://docs.sympy.org/latest/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 nitpick_ignore_regex = [


### PR DESCRIPTION
Removes the warning
```
WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/3/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping
```