### PR TITLE
[debug] Simplify condition in P2P

### DIFF
--- a/sumpy/p2p.py
+++ b/sumpy/p2p.py
@@ -491,7 +491,8 @@ class P2PFromCSR(P2PBase):
                 "{[istrength]: 0 <= istrength < nstrengths}",
                 "{[inner]: 0 <= inner < work_items_per_group}",
                 "{[itgt_offset_outer]: 0 <= itgt_offset_outer <= tgt_outer_limit}",
-                "{[isrc_prefetch]: 0 <= isrc_prefetch < max_nsources_in_one_box}",
+                "{[isrc_prefetch]: 0 <= isrc_prefetch < max_nsources_in_one_box "
+                " and isrc_prefetch < isrc_end - isrc_start}",
                 "{[isrc_offset]: 0 <= isrc_offset < max_nsources_in_one_box"
                 " and isrc_offset < isrc_end - isrc_start}",
             ]
@@ -530,14 +531,10 @@ class P2PFromCSR(P2PBase):
                     <> isrc_end = isrc_start + box_source_counts_nonchild[src_ibox] \
                         {id=src_box_insn_2}
                     for isrc_prefetch
-                      <> cond_isrc_prefetch = isrc_prefetch < isrc_end - isrc_start \
-                              {id=cond_isrc_prefetch}
-                      if cond_isrc_prefetch
-                        local_isrc[idim, isrc_prefetch] = sources[idim,
-                          isrc_prefetch + isrc_start]  {id=prefetch_src, dup=idim}
-                        local_isrc_strength[istrength, isrc_prefetch] = strength[
-                          istrength, isrc_prefetch + isrc_start] {id=prefetch_charge}
-                      end
+                      local_isrc[idim, isrc_prefetch] = sources[idim,
+                        isrc_prefetch + isrc_start]  {id=prefetch_src, dup=idim}
+                      local_isrc_strength[istrength, isrc_prefetch] = strength[
+                        istrength, isrc_prefetch + isrc_start] {id=prefetch_charge}
                     end
                     for inner
                       if cond_itgt


### PR DESCRIPTION
@inducer, this is not a big deal, but loopy fails with
```
loopy.diagnostic.CannotBranchDomainTree: iname set 'isrc_prefetch_inner_inner, isrc_prefetch_inner_outer, iprefetch' requires branch in domain tree (when adding 'iprefetch')
```
I'm keeping this here so that I might remember to debug this in the future.