### PR TITLE
no_numpy in sumpy kernels

### DIFF
--- a/examples/curve-pot.py
+++ b/examples/curve-pot.py
@@ -91,7 +91,8 @@ def draw_pot_figure(aspect_ratio,
         knl_kwargs = {}
 
     vol_source_knl, vol_target_knl = process_kernel(knl, what_operator)
-    p2p = P2P(actx.context, source_kernels=(vol_source_knl,),
+    p2p = P2P(actx.context,
+            source_kernels=(vol_source_knl,),
             target_kernels=(vol_target_knl,),
             exclude_self=False,
             value_dtypes=np.complex128)
@@ -157,35 +158,40 @@ def draw_pot_figure(aspect_ratio,
     lpot_kwargs = knl_kwargs.copy()
 
     if what_operator == "D":
-        volpot_kwargs["src_derivative_dir"] = native_curve.normal
+        volpot_kwargs["src_derivative_dir"] = actx.from_numpy(native_curve.normal)
 
     if what_operator_lpot == "D":
-        lpot_kwargs["src_derivative_dir"] = ovsmp_curve.normal
+        lpot_kwargs["src_derivative_dir"] = actx.from_numpy(ovsmp_curve.normal)
 
     if what_operator_lpot == "S'":
-        lpot_kwargs["tgt_derivative_dir"] = native_curve.normal
+        lpot_kwargs["tgt_derivative_dir"] = actx.from_numpy(native_curve.normal)
 
     # }}}
+
+    targets = actx.from_numpy(fp.points)
+    sources = actx.from_numpy(native_curve.pos)
+    ovsmp_sources = actx.from_numpy(ovsmp_curve.pos)
 
     if 0:
         # {{{ build matrix
 
         from fourier import make_fourier_interp_matrix
         fim = make_fourier_interp_matrix(novsmp, nsrc)
+
         from sumpy.tools import build_matrix
         from scipy.sparse.linalg import LinearOperator
 
         def apply_lpot(x):
             xovsmp = np.dot(fim, x)
             evt, (y,) = lpot(actx.queue,
-                    native_curve.pos,
-                    ovsmp_curve.pos,
-                    centers,
-                    [xovsmp * ovsmp_curve.speed * ovsmp_weights],
-                    expansion_radii=np.ones(centers.shape[1]),
+                    sources,
+                    ovsmp_sources,
+                    actx.from_numpy(centers),
+                    [actx.from_numpy(xovsmp * ovsmp_curve.speed * ovsmp_weights)],
+                    expansion_radii=actx.from_numpy(np.ones(centers.shape[1])),
                     **lpot_kwargs)
 
-            return y
+            return actx.to_numpy(y)
 
         op = LinearOperator((nsrc, nsrc), apply_lpot)
         mat = build_matrix(op, dtype=np.complex128)
@@ -200,19 +206,26 @@ def draw_pot_figure(aspect_ratio,
 
     mode_nr = 0
     density = np.cos(mode_nr*2*np.pi*native_t).astype(np.complex128)
-    ovsmp_density = np.cos(mode_nr*2*np.pi*ovsmp_t).astype(np.complex128)
+    strength = actx.from_numpy(native_curve.speed * native_weights * density)
+
     evt, (vol_pot,) = p2p(actx.queue,
-            fp.points,
-            native_curve.pos,
-            [native_curve.speed*native_weights*density], **volpot_kwargs)
+            targets,
+            sources,
+            [strength], **volpot_kwargs)
+    vol_pot = actx.to_numpy(vol_pot)
+
+    ovsmp_density = np.cos(mode_nr*2*np.pi*ovsmp_t).astype(np.complex128)
+    ovsmp_strength = actx.from_numpy(
+        ovsmp_curve.speed * ovsmp_weights * ovsmp_density)
 
     evt, (curve_pot,) = lpot(actx.queue,
-            native_curve.pos,
-            ovsmp_curve.pos,
-            centers,
-            [ovsmp_density * ovsmp_curve.speed * ovsmp_weights],
-            expansion_radii=np.ones(centers.shape[1]),
+            sources,
+            ovsmp_sources,
+            actx.from_numpy(centers),
+            [ovsmp_strength],
+            expansion_radii=actx.from_numpy(np.ones(centers.shape[1])),
             **lpot_kwargs)
+    curve_pot = actx.to_numpy(curve_pot)
 
     # }}}
 

--- a/sumpy/toys.py
+++ b/sumpy/toys.py
@@ -226,8 +226,6 @@ def _p2e(psource, center, rscale, order, p2e, expn_class, expn_kwargs):
             rscale=rscale,
             nboxes=1,
             tgt_base_ibox=0,
-
-            out_host=True,
             **toy_ctx.extra_source_and_kernel_kwargs)
 
     return expn_class(toy_ctx, center, rscale, order, coeffs[0].get(queue),
@@ -264,8 +262,6 @@ def _e2p(psource, targets, e2p):
             centers=centers,
             rscale=psource.rscale,
             targets=vector_to_device(queue, make_obj_array(targets)),
-
-            out_host=True,
             **toy_ctx.extra_kernel_kwargs)
 
     return pot.get(queue)
@@ -311,8 +307,7 @@ def _e2e(psource, to_center, to_rscale, to_order, e2e, expn_class, expn_kwargs):
 
             src_rscale=psource.rscale,
             tgt_rscale=to_rscale,
-
-            out_host=True, **toy_ctx.extra_kernel_kwargs)
+            **toy_ctx.extra_kernel_kwargs)
 
     return expn_class(
             toy_ctx, to_center, to_rscale, to_order, to_coeffs[1].get(queue),
@@ -467,7 +462,6 @@ class PointSources(PotentialSource):
                 cl.array.to_device(queue, targets),
                 cl.array.to_device(queue, self.points),
                 [cl.array.to_device(queue, self.weights)],
-                out_host=True,
                 **self.toy_ctx.extra_source_and_kernel_kwargs)
 
         return potential.get(queue)

--- a/test/test_fmm.py
+++ b/test/test_fmm.py
@@ -62,9 +62,13 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
 
 # {{{ test_sumpy_fmm
 
-@pytest.mark.parametrize("use_translation_classes, use_fft, fft_backend",
-    [(False, False, None), (True, False, None), (True, True, "loopy"),
-     (True, True, "pyvkfft")])
+@pytest.mark.parametrize(
+    ("use_translation_classes", "use_fft", "fft_backend"), [
+        (False, False, None),
+        (True, False, None),
+        (True, True, "loopy"),
+        (True, True, "pyvkfft"),
+    ])
 @pytest.mark.parametrize(
         ("knl", "local_expn_class", "mpole_expn_class",
         "order_varies_with_level"), [
@@ -92,6 +96,9 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
 def test_sumpy_fmm(actx_factory, knl, local_expn_class, mpole_expn_class,
         order_varies_with_level, use_translation_classes, use_fft,
         fft_backend, visualize=False):
+    if fft_backend == "pyvkfft":
+        pytest.importorskip("pyvkfft")
+
     if visualize:
         logging.basicConfig(level=logging.INFO)
 
@@ -399,7 +406,7 @@ def test_unified_single_and_double(actx_factory, visualize=False):
     strength_usages = [[0], [1], [0, 1]]
 
     alpha = np.linspace(0, 2*np.pi, nsources, np.float64)
-    dir_vec = np.vstack([np.cos(alpha), np.sin(alpha)])
+    dir_vec = actx.from_numpy(np.vstack([np.cos(alpha), np.sin(alpha)]))
 
     results = []
     for source_kernels, strength_usage in zip(source_kernel_vecs, strength_usages):
@@ -528,7 +535,7 @@ def test_sumpy_fmm_exclude_self(actx_factory, visualize=False):
     rng = np.random.default_rng(44)
     weights = actx.from_numpy(rng.random(nsources, dtype=np.float64))
 
-    target_to_source = np.arange(tree.ntargets, dtype=np.int32)
+    target_to_source = actx.from_numpy(np.arange(tree.ntargets, dtype=np.int32))
     self_extra_kwargs = {"target_to_source": target_to_source}
 
     target_kernels = [knl]
@@ -597,7 +604,7 @@ def test_sumpy_axis_source_derivative(actx_factory, visualize=False):
     rng = np.random.default_rng(12)
     weights = actx.from_numpy(rng.random(nsources, dtype=np.float64))
 
-    target_to_source = np.arange(tree.ntargets, dtype=np.int32)
+    target_to_source = actx.from_numpy(np.arange(tree.ntargets, dtype=np.int32))
     self_extra_kwargs = {"target_to_source": target_to_source}
 
     from sumpy.kernel import AxisTargetDerivative, AxisSourceDerivative
@@ -665,7 +672,7 @@ def test_sumpy_target_point_multiplier(actx_factory, deriv_axes, visualize=False
     rng = np.random.default_rng(12)
     weights = actx.from_numpy(rng.random(nsources, dtype=np.float64))
 
-    target_to_source = np.arange(tree.ntargets, dtype=np.int32)
+    target_to_source = actx.from_numpy(np.arange(tree.ntargets, dtype=np.int32))
     self_extra_kwargs = {"target_to_source": target_to_source}
 
     from sumpy.kernel import TargetPointMultiplier, AxisTargetDerivative

--- a/test/test_kernels.py
+++ b/test/test_kernels.py
@@ -26,6 +26,7 @@ import sys
 import numpy as np
 import numpy.linalg as la
 
+from pytools.obj_array import make_obj_array
 from pytools.convergence import PConvergenceVerifier
 from arraycontext import pytest_generate_tests_for_array_contexts
 from sumpy.array_context import (                                 # noqa: F401
@@ -76,20 +77,23 @@ def test_p2p(actx_factory, exclude_self):
     rng = np.random.default_rng(42)
     targets = rng.random(size=(dimensions, n))
     sources = targets if exclude_self else rng.random(size=(dimensions, n))
-
     strengths = np.ones(n, dtype=np.float64)
 
     extra_kwargs = {}
 
     if exclude_self:
-        extra_kwargs["target_to_source"] = np.arange(n, dtype=np.int32)
+        extra_kwargs["target_to_source"] = (
+            actx.from_numpy(np.arange(n, dtype=np.int32)))
 
     evt, (potential, x_derivative) = knl(
-            actx.queue, targets, sources, [strengths],
+            actx.queue,
+            actx.from_numpy(targets),
+            actx.from_numpy(sources),
+            [actx.from_numpy(strengths)],
             out_host=True, **extra_kwargs)
+    potential = actx.to_numpy(potential)
 
     potential_ref = np.empty_like(potential)
-
     targets = targets.T
     sources = sources.T
     for itarg in range(n):
@@ -146,21 +150,22 @@ def test_p2e_multiple(actx_factory, base_knl, expn_class):
 
     rng = np.random.default_rng(14)
     center = np.array([2, 1, 0][:knl.dim], np.float64)
-    sources = (
+    sources = actx.from_numpy(
         0.7 * (-0.5 + rng.random(size=(knl.dim, nsources), dtype=np.float64))
         + center[:, np.newaxis])
 
     strengths = [
-        np.ones(nsources, dtype=np.float64) * (1/nsources),
-        np.ones(nsources, dtype=np.float64) * (2/nsources)
+        actx.from_numpy(np.ones(nsources, dtype=np.float64) * (1/nsources)),
+        actx.from_numpy(np.ones(nsources, dtype=np.float64) * (2/nsources))
     ]
 
-    source_boxes = np.array([0], dtype=np.int32)
-    box_source_starts = np.array([0], dtype=np.int32)
-    box_source_counts_nonchild = np.array([nsources], dtype=np.int32)
+    source_boxes = actx.from_numpy(np.array([0], dtype=np.int32))
+    box_source_starts = actx.from_numpy(np.array([0], dtype=np.int32))
+    box_source_counts_nonchild = (
+        actx.from_numpy(np.array([nsources], dtype=np.int32)))
 
     alpha = np.linspace(0, 2*np.pi, nsources, np.float64)
-    dir_vec = np.vstack([np.cos(alpha), np.sin(alpha)])
+    dir_vec = actx.from_numpy(np.vstack([np.cos(alpha), np.sin(alpha)]))
 
     from sumpy.expansion.local import LocalExpansionBase
     if issubclass(expn_class, LocalExpansionBase):
@@ -170,6 +175,7 @@ def test_p2e_multiple(actx_factory, base_knl, expn_class):
         centers = (np.array([0.0, 0.0, 0.0][:knl.dim],
                             dtype=np.float64).reshape(knl.dim, 1)
                     + center[:, np.newaxis])
+    centers = actx.from_numpy(centers)
 
     rscale = 0.5  # pick something non-1
 
@@ -193,7 +199,7 @@ def test_p2e_multiple(actx_factory, base_knl, expn_class):
             dir_vec=dir_vec,
             **extra_kwargs)
 
-    actual_result = mpoles
+    actual_result = actx.to_numpy(mpoles)
 
     # apply p2e separately
     expected_result = np.zeros_like(actual_result)
@@ -217,6 +223,8 @@ def test_p2e_multiple(actx_factory, base_knl, expn_class):
             rscale=rscale,
 
             out_host=True, **extra_source_kwargs)
+        mpoles = actx.to_numpy(mpoles)
+
         expected_result += mpoles
 
     norm = la.norm(actual_result - expected_result)/la.norm(expected_result)
@@ -302,21 +310,22 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
 
     rng = np.random.default_rng(19)
     center = np.array([2, 1, 0][:knl.dim], np.float64)
-    sources = (
+    sources = actx.from_numpy(
         0.7 * (-0.5 + rng.random((knl.dim, nsources), dtype=np.float64))
         + center[:, np.newaxis])
 
-    strengths = np.ones(nsources, dtype=np.float64) / nsources
+    strengths = actx.from_numpy(np.ones(nsources, dtype=np.float64) / nsources)
 
-    source_boxes = np.array([0], dtype=np.int32)
-    box_source_starts = np.array([0], dtype=np.int32)
-    box_source_counts_nonchild = np.array([nsources], dtype=np.int32)
+    source_boxes = actx.from_numpy(np.array([0], dtype=np.int32))
+    box_source_starts = actx.from_numpy(np.array([0], dtype=np.int32))
+    box_source_counts_nonchild = (
+        actx.from_numpy(np.array([nsources], dtype=np.int32)))
 
     extra_source_kwargs = extra_kwargs.copy()
     if isinstance(knl, DirectionalSourceDerivative):
         alpha = np.linspace(0, 2*np.pi, nsources, np.float64)
         dir_vec = np.vstack([np.cos(alpha), np.sin(alpha)])
-        extra_source_kwargs["dir_vec"] = dir_vec
+        extra_source_kwargs["dir_vec"] = actx.from_numpy(dir_vec)
 
     from sumpy.visualization import FieldPlotter
 
@@ -332,7 +341,8 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
                                 dtype=np.float64).reshape(knl.dim, 1)
                         + center[:, np.newaxis])
 
-        targets = fp.points
+        centers = actx.from_numpy(centers)
+        targets = actx.from_numpy(make_obj_array(fp.points))
 
         rscale = 0.5  # pick something non-1
 
@@ -355,10 +365,11 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
 
         # {{{ apply e2p
 
-        ntargets = targets.shape[-1]
+        ntargets = fp.points.shape[-1]
 
-        box_target_starts = np.array([0], dtype=np.int32)
-        box_target_counts_nonchild = np.array([ntargets], dtype=np.int32)
+        box_target_starts = actx.from_numpy(np.array([0], dtype=np.int32))
+        box_target_counts_nonchild = (
+            actx.from_numpy(np.array([ntargets], dtype=np.int32)))
 
         evt, (pot, grad_x, ) = e2p(
                 actx.queue,
@@ -372,6 +383,8 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
                 rscale=rscale,
 
                 out_host=True, **extra_kwargs)
+        pot = actx.to_numpy(pot)
+        grad_x = actx.to_numpy(grad_x)
 
         # }}}
 
@@ -382,6 +395,8 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
                 targets, sources, (strengths,),
                 out_host=True,
                 **extra_source_kwargs)
+        pot_direct = actx.to_numpy(pot_direct)
+        grad_x_direct = actx.to_numpy(grad_x_direct)
 
         err_pot = la.norm((pot - pot_direct)/res**2)
         err_grad_x = la.norm((grad_x - grad_x_direct)/res**2)
@@ -501,10 +516,11 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
     # Just to make sure things also work away from the origin
     rng = np.random.default_rng(18)
     origin = np.array([2, 1, 0][:knl.dim], np.float64)
-    sources = (
+    sources = actx.from_numpy(
         0.7 * (-0.5 + rng.random((knl.dim, nsources), dtype=np.float64))
         + origin[:, np.newaxis])
-    strengths = np.ones(nsources, dtype=np.float64) * (1/nsources)
+    strengths = actx.from_numpy(
+        np.ones(nsources, dtype=np.float64) * (1/nsources))
 
     pconv_verifier_p2m2p = PConvergenceVerifier()
     pconv_verifier_p2m2m2p = PConvergenceVerifier()
@@ -514,8 +530,9 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
     from sumpy.visualization import FieldPlotter
 
     eval_offset = np.array([5.5, 0.0, 0][:knl.dim])
+    fp = FieldPlotter(eval_offset + origin, extent=0.3, npoints=res)
 
-    centers = (np.array(
+    centers = actx.from_numpy((np.array(
             [
                 # box 0: particles, first mpole here
                 [0, 0, 0][:knl.dim],
@@ -529,7 +546,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
                 # box 3: second local and eval here
                 eval_offset
                 ],
-            dtype=np.float64) + origin).T.copy()
+            dtype=np.float64) + origin).T.copy())
 
     del eval_offset
 
@@ -541,13 +558,15 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
     nboxes = centers.shape[-1]
 
     def eval_at(e2p, source_box_nr, rscale):
-        e2p_target_boxes = np.array([source_box_nr], dtype=np.int32)
+        e2p_target_boxes = actx.from_numpy(
+            np.array([source_box_nr], dtype=np.int32))
 
         # These are indexed by global box numbers.
-        e2p_box_target_starts = np.array([0, 0, 0, 0], dtype=np.int32)
-        e2p_box_target_counts_nonchild = np.array([0, 0, 0, 0],
-                dtype=np.int32)
-        e2p_box_target_counts_nonchild[source_box_nr] = ntargets
+        e2p_box_target_starts = actx.from_numpy(
+            np.array([0, 0, 0, 0], dtype=np.int32))
+        e2p_box_target_counts_nonchild = actx.from_numpy(
+            np.array([0, 0, 0, 0], dtype=np.int32))
+        e2p_box_target_counts_nonchild[source_box_nr] = fp.points.shape[-1]
 
         evt, (pot,) = e2p(
                 actx.queue,
@@ -565,6 +584,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
                 out_host=True, **extra_kwargs
                 )
+        pot = actx.to_numpy(pot)
 
         return pot
 
@@ -584,8 +604,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
         l2p = E2PFromSingleBox(actx.context, l_expn, target_kernels)
         p2p = P2P(actx.context, target_kernels, exclude_self=False)
 
-        fp = FieldPlotter(centers[:, -1], extent=0.3, npoints=res)
-        targets = fp.points
+        targets = actx.from_numpy(make_obj_array(fp.points))
 
         # {{{ compute (direct) reference solution
 
@@ -593,6 +612,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
                 actx.queue,
                 targets, sources, (strengths,),
                 out_host=True, **extra_kwargs)
+        pot_direct = actx.to_numpy(pot_direct)
 
         # }}}
 
@@ -603,12 +623,13 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
         # {{{ apply P2M
 
-        p2m_source_boxes = np.array([0], dtype=np.int32)
+        p2m_source_boxes = actx.from_numpy(np.array([0], dtype=np.int32))
 
         # These are indexed by global box numbers.
-        p2m_box_source_starts = np.array([0, 0, 0, 0], dtype=np.int32)
-        p2m_box_source_counts_nonchild = np.array([nsources, 0, 0, 0],
-                dtype=np.int32)
+        p2m_box_source_starts = actx.from_numpy(
+            np.array([0, 0, 0, 0], dtype=np.int32))
+        p2m_box_source_counts_nonchild = actx.from_numpy(
+            np.array([nsources, 0, 0, 0], dtype=np.int32))
 
         evt, (mpoles,) = p2m(actx.queue,
                 source_boxes=p2m_source_boxes,
@@ -626,20 +647,18 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
         # }}}
 
-        ntargets = targets.shape[-1]
-
         pot = eval_at(m2p, 0, m1_rscale)
 
-        err = la.norm((pot - pot_direct)/res**2)
+        err = la.norm((pot - pot_direct) / res**2)
         err = err / (la.norm(pot_direct) / res**2)
 
         pconv_verifier_p2m2p.add_data_point(order, err)
 
         # {{{ apply M2M
 
-        m2m_target_boxes = np.array([1], dtype=np.int32)
-        m2m_src_box_starts = np.array([0, 1], dtype=np.int32)
-        m2m_src_box_lists = np.array([0], dtype=np.int32)
+        m2m_target_boxes = actx.from_numpy(np.array([1], dtype=np.int32))
+        m2m_src_box_starts = actx.from_numpy(np.array([0, 1], dtype=np.int32))
+        m2m_src_box_lists = actx.from_numpy(np.array([0], dtype=np.int32))
 
         evt, (mpoles,) = m2m(actx.queue,
                 src_expansions=mpoles,
@@ -669,9 +688,9 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
         # {{{ apply M2L
 
-        m2l_target_boxes = np.array([2], dtype=np.int32)
-        m2l_src_box_starts = np.array([0, 1], dtype=np.int32)
-        m2l_src_box_lists = np.array([1], dtype=np.int32)
+        m2l_target_boxes = actx.from_numpy(np.array([2], dtype=np.int32))
+        m2l_src_box_starts = actx.from_numpy(np.array([0, 1], dtype=np.int32))
+        m2l_src_box_lists = actx.from_numpy(np.array([1], dtype=np.int32))
 
         evt, (mpoles,) = m2l(actx.queue,
                 src_expansions=mpoles,
@@ -700,9 +719,9 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
         # {{{ apply L2L
 
-        l2l_target_boxes = np.array([3], dtype=np.int32)
-        l2l_src_box_starts = np.array([0, 1], dtype=np.int32)
-        l2l_src_box_lists = np.array([2], dtype=np.int32)
+        l2l_target_boxes = actx.from_numpy(np.array([3], dtype=np.int32))
+        l2l_src_box_starts = actx.from_numpy(np.array([0, 1], dtype=np.int32))
+        l2l_src_box_lists = actx.from_numpy(np.array([2], dtype=np.int32))
 
         evt, (mpoles,) = l2l(actx.queue,
                 src_expansions=mpoles,

--- a/test/test_kernels.py
+++ b/test/test_kernels.py
@@ -90,7 +90,7 @@ def test_p2p(actx_factory, exclude_self):
             actx.from_numpy(targets),
             actx.from_numpy(sources),
             [actx.from_numpy(strengths)],
-            out_host=True, **extra_kwargs)
+            **extra_kwargs)
     potential = actx.to_numpy(potential)
 
     potential_ref = np.empty_like(potential)
@@ -194,8 +194,6 @@ def test_p2e_multiple(actx_factory, base_knl, expn_class):
             nboxes=1,
             tgt_base_ibox=0,
             rscale=rscale,
-
-            out_host=True,
             dir_vec=dir_vec,
             **extra_kwargs)
 
@@ -221,8 +219,7 @@ def test_p2e_multiple(actx_factory, base_knl, expn_class):
             nboxes=1,
             tgt_base_ibox=0,
             rscale=rscale,
-
-            out_host=True, **extra_source_kwargs)
+            **extra_source_kwargs)
         mpoles = actx.to_numpy(mpoles)
 
         expected_result += mpoles
@@ -358,8 +355,7 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
                 nboxes=1,
                 tgt_base_ibox=0,
                 rscale=rscale,
-
-                out_host=True, **extra_source_kwargs)
+                **extra_source_kwargs)
 
         # }}}
 
@@ -381,8 +377,7 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
                 centers=centers,
                 targets=targets,
                 rscale=rscale,
-
-                out_host=True, **extra_kwargs)
+                **extra_kwargs)
         pot = actx.to_numpy(pot)
         grad_x = actx.to_numpy(grad_x)
 
@@ -393,7 +388,6 @@ def test_p2e2p(actx_factory, base_knl, expn_class, order, with_source_derivative
         evt, (pot_direct, grad_x_direct, ) = p2p(
                 actx.queue,
                 targets, sources, (strengths,),
-                out_host=True,
                 **extra_source_kwargs)
         pot_direct = actx.to_numpy(pot_direct)
         grad_x_direct = actx.to_numpy(grad_x_direct)
@@ -581,8 +575,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
                 targets=targets,
 
                 rscale=rscale,
-
-                out_host=True, **extra_kwargs
+                **extra_kwargs
                 )
         pot = actx.to_numpy(pot)
 
@@ -611,7 +604,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
         evt, (pot_direct,) = p2p(
                 actx.queue,
                 targets, sources, (strengths,),
-                out_host=True, **extra_kwargs)
+                **extra_kwargs)
         pot_direct = actx.to_numpy(pot_direct)
 
         # }}}
@@ -642,8 +635,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
                 rscale=m1_rscale,
 
                 tgt_base_ibox=0,
-
-                out_host=True, **extra_kwargs)
+                **extra_kwargs)
 
         # }}}
 
@@ -674,8 +666,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
                 src_rscale=m1_rscale,
                 tgt_rscale=m2_rscale,
-
-                out_host=True, **extra_kwargs)
+                **extra_kwargs)
 
         # }}}
 
@@ -705,8 +696,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
                 src_rscale=m2_rscale,
                 tgt_rscale=l1_rscale,
-
-                out_host=True, **extra_kwargs)
+                **extra_kwargs)
 
         # }}}
 
@@ -736,8 +726,7 @@ def test_translations(actx_factory, knl, local_expn_class, mpole_expn_class,
 
                 src_rscale=l1_rscale,
                 tgt_rscale=l2_rscale,
-
-                out_host=True, **extra_kwargs)
+                **extra_kwargs)
 
         # }}}
 

--- a/test/test_qbx.py
+++ b/test/test_qbx.py
@@ -86,19 +86,19 @@ def test_direct_qbx_vs_eigval(actx_factory, expn_class, visualize=False):
 
         h = 2 * np.pi / n
 
-        targets = unit_circle
-        sources = unit_circle
+        targets = actx.from_numpy(unit_circle)
+        sources = actx.from_numpy(unit_circle)
 
         radius = 7 * h
-        centers = unit_circle * (1 - radius)
+        centers = actx.from_numpy((1 - radius) * unit_circle)
+        expansion_radii = actx.from_numpy(radius * np.ones(n))
+        strengths = (actx.from_numpy(sigma * h),)
 
-        expansion_radii = np.ones(n) * radius
-
-        strengths = (sigma * h,)
         evt, (result_qbx,) = lpot(
                 actx.queue,
                 targets, sources, centers, strengths,
                 expansion_radii=expansion_radii)
+        result_qbx = actx.to_numpy(result_qbx)
 
         eocrec.add_data_point(h, np.max(np.abs(result_ref - result_qbx)))
 
@@ -157,22 +157,25 @@ def test_direct_qbx_vs_eigval_with_tgt_deriv(
 
         h = 2 * np.pi / n
 
-        targets = unit_circle
-        sources = unit_circle
+        targets = actx.from_numpy(unit_circle)
+        sources = actx.from_numpy(unit_circle)
 
         radius = 7 * h
-        centers = unit_circle * (1 - radius)
+        centers = actx.from_numpy((1 - radius) * unit_circle)
+        expansion_radii = actx.from_numpy(radius * np.ones(n))
+        strengths = (actx.from_numpy(sigma * h),)
 
-        expansion_radii = np.ones(n) * radius
-
-        strengths = (sigma * h,)
-
-        evt, (result_qbx_dx,) = lpot_dx(actx.queue,
+        evt, (result_qbx_dx,) = lpot_dx(
+                actx.queue,
                 targets, sources, centers, strengths,
                 expansion_radii=expansion_radii)
-        evt, (result_qbx_dy,) = lpot_dy(actx.queue,
+        evt, (result_qbx_dy,) = lpot_dy(
+                actx.queue,
                 targets, sources, centers, strengths,
                 expansion_radii=expansion_radii)
+
+        result_qbx_dx = actx.to_numpy(result_qbx_dx)
+        result_qbx_dy = actx.to_numpy(result_qbx_dy)
 
         normals = unit_circle
         result_qbx = normals[0] * result_qbx_dx + normals[1] * result_qbx_dy


### PR DESCRIPTION
This takes another chunk from #118. 

Namely, using [make_loopy_program](https://github.com/inducer/arraycontext/blob/main/arraycontext/loopy.py#L42-L64) (or something like it) from `arraycontext` will add a `no_numpy=True` to all kernels. This updates all the tests and other call sites to never pass numpy arrays in.

The stuff in `sumpy.toys` still takes numpy arrays and does all the back and forth behind the scenes.