### PR TITLE
Pass all arguments to CSE constructor

### DIFF
--- a/sumpy/codegen.py
+++ b/sumpy/codegen.py
@@ -290,7 +290,8 @@ class BesselDerivativeReplacer(CSECachingIdentityMapper, CallExternalRecMapper):
                     2**(-k)*sum(
                         (-1)**idx*int(sym.binomial(k, idx)) * function(i, arg)
                         for idx, i in enumerate(range(order-k, order+k+1, 2))),
-                    f"d{n_derivs}_{function.name}_{order_str}")
+                    f"d{n_derivs}_{function.name}_{order_str}",
+                    scope=prim.cse_scope.EVALUATION)
         else:
             return CSECachingIdentityMapper.map_call(
                     rec_self or self, expr, rec_self, *args)

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -1077,11 +1077,12 @@ class _VectorIndexAdder(CSECachingMapperMixin, IdentityMapper):
         self.additional_indices = additional_indices
 
     def map_subscript(self, expr):
-        from pymbolic.primitives import CommonSubexpression
+        from pymbolic.primitives import CommonSubexpression, cse_scope
         if expr.aggregate.name == self.vec_name \
                 and isinstance(expr.index, int):
-            return CommonSubexpression(expr.aggregate.index(
-                    (expr.index,) + self.additional_indices))
+            return CommonSubexpression(
+                    expr.aggregate.index((expr.index,) + self.additional_indices),
+                    prefix=None, scope=cse_scope.EVALUATION)
         else:
             return IdentityMapper.map_subscript(self, expr)
 


### PR DESCRIPTION
Was playing with adding `__slots__` to pymbolic expressions on the `attrs` branch. That doesn't work with default arguments, since it considers them class attributes and `dataclass` gets confused.

Very few expressions had that issue though, mostly just `CommonSubexpression` and `NaN`, and this fixes it here if we ever want to try it!