### PR TITLE
Fix ruff issues in notebooks

### DIFF
--- a/contrib/translations/PDE-reduction and translations.ipynb
+++ b/contrib/translations/PDE-reduction and translations.ipynb
@@ -2,35 +2,39 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pyopencl as cl\n",
-    "import sumpy.toys as t\n",
+    "from __future__ import annotations\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import numpy.linalg as la\n",
-    "import matplotlib.pyplot as plt\n",
-    "from sumpy.visualization import FieldPlotter\n",
+    "\n",
+    "import pyopencl as cl\n",
     "from pytools import add_tuples\n",
     "\n",
+    "import sumpy.toys as t\n",
     "from sumpy.expansion.local import VolumeTaylorLocalExpansion\n",
     "from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion\n",
-    "from sumpy.kernel import (YukawaKernel, HelmholtzKernel, LaplaceKernel)\n",
+    "from sumpy.kernel import HelmholtzKernel, LaplaceKernel, YukawaKernel  # noqa: F401\n",
     "\n",
+    "\n",
+    "rng = np.random.default_rng(seed=42)\n",
     "order = 4\n",
     "\n",
     "if 0:\n",
     "    knl = LaplaceKernel(2)\n",
-    "    pde = [(1, (2,0)), (1, (0, 2))]\n",
+    "    pde = [(1, (2, 0)), (1, (0, 2))]\n",
     "    extra_kernel_kwargs = {}\n",
-    "    \n",
+    "\n",
     "else:\n",
     "    helm_k = 1.2\n",
     "    knl = HelmholtzKernel(2)\n",
-    "    extra_kernel_kwargs={\"k\": helm_k}\n",
+    "    extra_kernel_kwargs = {\"k\": helm_k}\n",
     "\n",
-    "    pde = [(1, (2,0)), (1, (0, 2)), (helm_k**2, (0, 0))]\n",
+    "    pde = [(1, (2, 0)), (1, (0, 2)), (helm_k**2, (0, 0))]\n",
     "\n",
     "mpole_expn = VolumeTaylorMultipoleExpansion(knl, order)\n",
     "local_expn = VolumeTaylorLocalExpansion(knl, order)\n",
@@ -38,145 +42,119 @@
     "cl_ctx = cl.create_some_context(answers=[\"port\"])\n",
     "\n",
     "tctx = t.ToyContext(\n",
-    "        cl_ctx,\n",
-    "        knl,\n",
-    "        mpole_expn_class=type(mpole_expn),\n",
-    "        local_expn_class=type(local_expn),\n",
-    "        extra_kernel_kwargs=extra_kernel_kwargs,\n",
-    "        )\n"
+    "    cl_ctx,\n",
+    "    knl,\n",
+    "    mpole_expn_class=type(mpole_expn),\n",
+    "    local_expn_class=type(local_expn),\n",
+    "    extra_kernel_kwargs=extra_kernel_kwargs,\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "pt_src = t.PointSources(\n",
-    "        tctx,\n",
-    "        np.random.rand(2, 50) - 0.5,\n",
-    "        np.ones(50))\n",
+    "pt_src = t.PointSources(tctx, rng.uniform(-0.5, 0.5, size=(2, 50)), np.ones(50))\n",
     "\n",
     "mexp = t.multipole_expand(pt_src, [0, 0], order)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([  5.00000000e+01,   4.76258789e+00,   6.63902810e-01,\n",
-       "         2.17149444e+00,   6.22396090e-01,   2.36567252e+00,\n",
-       "         5.93173776e-02,   6.33392972e-02,   1.15590385e-01,\n",
-       "         2.35250166e-02,   2.60421537e-02,   1.58948983e-02,\n",
-       "         9.97399769e-02,   1.12510066e-02,   3.13387666e-02])"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "mexp.coeffs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def build_pde_mat(expn, pde):\n",
     "    coeff_ids = expn.get_coefficient_identifiers()\n",
     "    id_to_index = expn._storage_loc_dict\n",
-    "    \n",
+    "\n",
     "    # FIXME: specific to scalar PDEs\n",
     "    pde_mat = np.zeros((len(coeff_ids), len(coeff_ids)))\n",
-    "    \n",
+    "\n",
     "    row = 0\n",
     "    for base_coeff_id in coeff_ids:\n",
     "        valid = True\n",
-    "        \n",
+    "\n",
     "        for pde_coeff, coeff_id_offset in pde:\n",
     "            other_coeff = add_tuples(base_coeff_id, coeff_id_offset)\n",
-    "            if not other_coeff in id_to_index:\n",
+    "            if other_coeff not in id_to_index:\n",
     "                valid = False\n",
     "                break\n",
-    "                \n",
+    "\n",
     "            pde_mat[row, id_to_index[other_coeff]] = pde_coeff\n",
-    "                \n",
+    "\n",
     "        if valid:\n",
     "            row += 1\n",
     "        else:\n",
     "            pde_mat[row] = 0\n",
-    "            \n",
+    "\n",
     "    return pde_mat[:row]\n",
+    "\n",
     "\n",
     "pde_mat = build_pde_mat(mpole_expn, pde)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def find_nullspace(mat, tol=1e-10):\n",
-    "    u, sig, vt = la.svd(pde_mat, full_matrices=True)\n",
+    "    _u, sig, vt = la.svd(pde_mat, full_matrices=True)\n",
     "    zerosig = np.where(np.abs(sig) < tol)[0]\n",
-    "    if zerosig:\n",
+    "    if zerosig.size:\n",
     "        nullsp_start = zerosig[0]\n",
     "        assert np.array_equal(zerosig, np.arange(nullsp_start, pde_mat.shape[1]))\n",
     "    else:\n",
     "        nullsp_start = pde_mat.shape[0]\n",
-    "                              \n",
+    "\n",
     "    return vt[nullsp_start:].T\n",
-    "    \n",
+    "\n",
+    "\n",
     "nullsp = find_nullspace(pde_mat)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4.3183836498795062e-16"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "la.norm(pde_mat @ nullsp)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "def build_translation_mat(mexp, to_center):\n",
     "    n = len(mexp.coeffs)\n",
     "    result = np.zeros((n, n))\n",
-    "    \n",
+    "\n",
     "    for j in range(n):\n",
     "        unit_coeffs = np.zeros(n)\n",
     "        unit_coeffs[j] = 1\n",
     "        unit_mexp = mexp.with_coeffs(unit_coeffs)\n",
-    "        \n",
+    "\n",
     "        result[:, j] = t.multipole_expand(unit_mexp, to_center).coeffs\n",
-    "        \n",
+    "\n",
     "    return result\n",
+    "\n",
     "\n",
     "new_center = np.array([0, 0.5])\n",
     "tmat = build_translation_mat(mexp, new_center)"
@@ -184,57 +162,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x7f7f8841ceb8>"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAADcBJREFUeJzt3X+s3XV9x/Hn29tS1gLSgijQZoVJ\nmoBZBmmw6uLMOn6OUP/wj5K5dWJCzOIGxkVLSGayv+ZcdFtmZhpwYxkBM4TZGBg0VbMsWaultoVa\naCtjUFspk4UKxpay9/4430su13N/fX/dc/08H8nN+fX59vvu99zX/Z7zPd/PeUdmIqk8b5vvAiTN\nD8MvFcrwS4Uy/FKhDL9UKMMvFcrwS4Uy/FKhDL9UqEV9ruz8FWO5etXiOS93cN/SDqqRfvn8nNc4\nlSdjNmN7Df/qVYv57mOr5rzcdRf9RgfVSL98dub2WY/1Zb9UKMMvFapR+CPi+oh4JiIOR8TmtoqS\n1L3a4Y+IMeDLwA3A5cAtEXF5W4VJ6laTPf/VwOHMfDYzTwEPABvaKUtS15qE/2LghQm3j1T3SVoA\nmoR/2GeJv/C1QBFxW0TsiohdL/3kjQark9SmJuE/Akz80H4lcHTyoMzckplrM3PtO84ba7A6SW1q\nEv7vAZdFxCURcQawEdjaTlmSulb7DL/MPB0RnwQeA8aAr2bm/tYqk9SpRqf3ZuYjwCMt1SKpR57h\nJxXK8EuF6nVW38F9S2vN0Hvs6J7a63RGoDSce36pUIZfKpThlwpl+KVCGX6pUIZfKpThlwpl+KVC\nGX6pUIZfKpThlwpl+KVCGX6pUL3O6ju5ahmHP71uzstdd1H9dTojUBrOPb9UKMMvFcrwS4Vq0qtv\nVUR8OyIORMT+iLi9zcIkdavJAb/TwKczc3dEnA08ERHbMvMHLdUmqUO19/yZeSwzd1fXfwocwF59\n0oLRynv+iFgNXAnsbOPfk9S9xuGPiLOArwN3ZOaJIY+/2ajzjVdfa7o6SS1pFP6IWMwg+Pdl5kPD\nxkxs1Dl21rImq5PUoiZH+wO4BziQmV9sryRJfWiy5/8A8PvAb0fEnurnxpbqktSxJl16/wOIFmuR\n1CPP8JMKZfilQkVm9rayc2JFvjfW97a+pupOB3YqsObLztzOiXx5Vm/H3fNLhTL8UqEMv1Qowy8V\nyvBLhTL8UqEMv1Qowy8VyvBLhTL8UqEMv1Qowy8VyvBLheq1UWddh7809+ae4979qR21l607O8/m\noFoI3PNLhTL8UqEMv1SoNpp2jEXE9yPim20UJKkfbez5b2fQp0/SAtK0Y89K4HeBu9spR1Jfmu75\n/xr4DPB/LdQiqUdN2nXdBBzPzCdmGPdmo87XOVl3dZJa1rRd180R8RzwAIO2Xf88edDERp2LWdJg\ndZLaVDv8mXlnZq7MzNXARuBbmfnR1iqT1Ck/55cK1cq5/Zn5HeA7bfxbkvrhnl8qlOGXCtXrlN44\ncwlj714z5+WaTMudj+nATabl2hxUfXHPLxXK8EuFMvxSoQy/VCjDLxXK8EuFMvxSoQy/VCjDLxXK\n8EuFMvxSoQy/VCjDLxUqMrO3lZ0TK/K9sb639ZXE5qAC2JnbOZEvx2zGuueXCmX4pUIZfqlQTdt1\nnRsRD0bE0xFxICLe11ZhkrrV9Gu8/gb4t8z8SEScASxtoSZJPagd/og4B/gg8IcAmXkKONVOWZK6\n1uRl/6XAS8A/RMT3I+LuiFjWUl2SOtYk/IuAq4C/z8wrgdeAzZMH2ahTGk1Nwn8EOJKZO6vbDzL4\nY/AWNuqURlOTRp0/Bl6IiPEv4l8P/KCVqiR1runR/j8G7quO9D8LfKx5SZL60Cj8mbkHWNtSLZJ6\n5Bl+UqEMv1SoXht1LjR1m3w2aSxal81BNVfu+aVCGX6pUIZfKpThlwpl+KVCGX6pUIZfKpThlwpl\n+KVCGX6pUIZfKpThlwpl+KVCLYhGnWNXrJl50BTe2P9M7WXrqjsbEOZnRmBdNgcdPTbqlDQjwy8V\nyvBLhWraqPNTEbE/Ip6KiPsj4sy2CpPUrdrhj4iLgT8B1mbme4AxYGNbhUnqVtOX/YuAX4mIRQw6\n9B5tXpKkPjTp2PMj4K+A54FjwCuZ+XhbhUnqVpOX/cuBDcAlwEXAsoj46JBxNuqURlCTl/2/A/xX\nZr6Uma8DDwHvnzzIRp3SaGoS/ueBdRGxNCKCQaPOA+2UJalrTd7z72TQlns38GT1b21pqS5JHWva\nqPNzwOdaqkVSjzzDTyqU4ZcK1e+U3redl+uW3DDn5fJk/Y8IS5kOvJCmAoPNQbvilF5JMzL8UqEM\nv1Qowy8VyvBLhTL8UqEMv1Qowy8VyvBLhTL8UqEMv1Qowy8VyvBLhVoQjTqlcTYHnZ6z+iTNyPBL\nhTL8UqFmDH9EfDUijkfEUxPuWxER2yLiUHW5vNsyJbVtNnv+fwSun3TfZmB7Zl4GbK9uS1pAZgx/\nZv478PKkuzcA91bX7wU+3HJdkjpW9z3/OzPzGEB1eUF7JUnqQ6OmHbMREbcBtwGcydKuVydpluru\n+V+MiAsBqsvjUw20Uac0muqGfyuwqbq+CfhGO+VI6stsPuq7H/hPYE1EHImIjwN/AVwTEYeAa6rb\nkhaQGd/zZ+YtUzzkSfrSAuYZflKhDL9UqM4/6lM/6jb4hIXV5LPJtFybg76Ve36pUIZfKpThlwpl\n+KVCGX6pUIZfKpThlwpl+KVCGX6pUIZfKpThlwpl+KVCGX6pUDbqnMbYFWtqLffG/mdarqRbdWcE\nLqTZgE0spOagNuqUNCPDLxXK8EuFqtuo8wsR8XRE7IuIhyPi3G7LlNS2uo06twHvycxfBw4Cd7Zc\nl6SO1WrUmZmPZ+bp6uYOYGUHtUnqUBvv+W8FHm3h35HUo0bf3hsRdwGngfumGWOjTmkE1Q5/RGwC\nbgLW5zRnCmXmFmALDE7yqbs+Se2qFf6IuB74LPBbmfmzdkuS1Ie6jTr/Djgb2BYReyLiKx3XKall\ndRt13tNBLZJ65Bl+UqEMv1SoBTGlN5Ysqb3OPHmy9rJ11Z0KDAtrOnApzUGb6Ls5qFN6Jc3I8EuF\nMvxSoQy/VCjDLxXK8EuFMvxSoQy/VCjDLxXK8EuFMvxSoQy/VCjDLxVqQczqa6KUGYELaTYg2Bx0\nJnVnA1593Qvs2vtzZ/VJmprhlwpl+KVC1WrUOeGxP42IjIjzuylPUlfqNuokIlYB1wDPt1yTpB7U\natRZ+RLwGcAuPNICVOs9f0TcDPwoM/e2XI+knsy5XVdELAXuAq6d5XgbdUojqM6e/9eAS4C9EfEc\nsBLYHRHvGjY4M7dk5trMXLuY+ifcSGrXnPf8mfkkcMH47eoPwNrM/J8W65LUsbqNOiUtcHUbdU58\nfHVr1UjqjWf4SYUy/FKhep3SGxEvAf89xcPnA6N00HDU6oHRq8l6pjcf9fxqZr5jNgN7Df90ImJX\nZq6d7zrGjVo9MHo1Wc/0Rq2eyXzZLxXK8EuFGqXwb5nvAiYZtXpg9GqynumNWj1vMTLv+SX1a5T2\n/JJ61Hv4I+L6iHgmIg5HxOYhjy+JiK9Vj++MiNUd1rIqIr4dEQciYn9E3D5kzIci4pWI2FP9/FlX\n9UxY53MR8WS1vl1DHo+I+NtqG+2LiKs6rGXNhP/7nog4ERF3TBrT6TYa9m1SEbEiIrZFxKHqcvkU\ny26qxhyKiE0d1vOFiHi6ej4ejohzp1h22ue2V5nZ2w8wBvwQuBQ4A9gLXD5pzB8BX6mubwS+1mE9\nFwJXVdfPBg4OqedDwDd73k7PAedP8/iNwKNAAOuAnT0+fz9m8Flyb9sI+CBwFfDUhPv+EthcXd8M\nfH7IciuAZ6vL5dX15R3Vcy2wqLr++WH1zOa57fOn7z3/1cDhzHw2M08BDwAbJo3ZANxbXX8QWB8R\ns/oe8rnKzGOZubu6/lPgAHBxF+tq2Qbgn3JgB3BuRFzYw3rXAz/MzKlO1OpEDv82qYm/J/cCHx6y\n6HXAtsx8OTP/F9jGkK+ka6OezHw8M09XN3cwmOo+0voO/8XACxNuH+EXw/bmmGpjvgKc13Vh1duL\nK4GdQx5+X0TsjYhHI+KKrmth8NVoj0fEE9WXoUw2m+3YhY3A/VM81vc2emdmHoPBH3EmTDOfYL62\n060MXpkNM9Nz25s5z+dvaNgefPLHDbMZ06qIOAv4OnBHZp6Y9PBuBi9zX42IG4F/BS7rsh7gA5l5\nNCIuALZFxNPV3ubNkocs0/U2OgO4GbhzyMPzsY1mYz62013AaeC+KYbM9Nz2pu89/xFg1YTbK4Gj\nU42JiEXA2xn+BaKtiIjFDIJ/X2Y+NPnxzDyRma9W1x8BFnf9VeWZebS6PA48zODt0kSz2Y5tuwHY\nnZkvTn5gPrYR8OL4W53q8viQMb1up+qA4k3A72X1Bn+yWTy3vek7/N8DLouIS6o9yUZg66QxW4Hx\no7IfAb411YZsqjqWcA9wIDO/OMWYd40fc4iIqxlss590UU+1jmURcfb4dQYHkib3TNgK/EF11H8d\n8Mr4S+AO3cIUL/n73kaVib8nm4BvDBnzGHBtRCyvPg24trqvdRFxPfBZ4ObM/NkUY2bz3Pan7yOM\nDI5UH2Rw1P+u6r4/Z7DRAM4E/gU4DHwXuLTDWn6TwcvAfcCe6udG4BPAJ6oxnwT2M/hkYgfw/o63\nz6XVuvZW6x3fRhNrCuDL1TZ8ksHXqHVZ01IGYX77hPt620YM/ugcA15nsDf/OIPjQNuBQ9Xlimrs\nWuDuCcveWv0uHQY+1mE9hxkcXxj/PRr/xOoi4JHpntv5+vEMP6lQnuEnFcrwS4Uy/FKhDL9UKMMv\nFcrwS4Uy/FKhDL9UqP8H8zJzDMuV3ZMAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7f42944978>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.imshow(tmat)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(15, 9)"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nullsp.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,23 +189,25 @@
     "    expansion_mat = nullsp\n",
     "elif 1:\n",
     "    chosen_indices_and_coeff_ids = [\n",
-    "        (i, cid) for i, cid in enumerate(mpole_expn.get_coefficient_identifiers())\n",
+    "        (i, cid)\n",
+    "        for i, cid in enumerate(mpole_expn.get_coefficient_identifiers())\n",
     "        if cid[0] < 2\n",
     "    ]\n",
     "    chosen_indices = [idx for idx, _ in chosen_indices_and_coeff_ids]\n",
-    "    \n",
-    "    expansion_mat = np.zeros(\n",
-    "        (len(mpole_expn.get_coefficient_identifiers()), len(chosen_indices_and_coeff_ids))\n",
-    "        )\n",
+    "\n",
+    "    expansion_mat = np.zeros((\n",
+    "        len(mpole_expn.get_coefficient_identifiers()),\n",
+    "        len(chosen_indices_and_coeff_ids),\n",
+    "    ))\n",
     "    for i, (idx, _) in enumerate(chosen_indices_and_coeff_ids):\n",
     "        expansion_mat[idx, i] = 1\n",
-    "        \n",
+    "\n",
     "    reduction_mat = (nullsp @ la.inv(nullsp[chosen_indices])).T"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,162 +218,83 @@
     "    plt.colorbar()\n",
     "\n",
     "    for cid, coeff in zip(expn.get_coefficient_identifiers(), coeffs):\n",
-    "        plt.text(cid[0], cid[1]+0.2, \"%.1f\" % coeff)\n"
+    "        plt.text(cid[0], cid[1] + 0.2, f\"{coeff:.1f}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAEACAYAAACeQuziAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3Xt8VOW56PHfk2RIuN+SoBAQFaQI\nxagBTBXrrdWmFqpSodLWitWj4m6r5Wi7PWUXD91bdz3Y5sCpxehGqRtrtSqtKB8QL20tYtDINQoI\nSriGO4FcJjPP+WMGGpNJspK5rTXzfD+f9WFmzZp3PYvJPHnzrvciqooxxhj3yUh2AMYYYyKzBG2M\nMS5lCdoYY1zKErQxxriUJWhjjHEpS9DGGONSnk3QIvIFEfmHiNSLyMw2jrtbRLaIiIpIbiJjNMaY\naHg2QQMHgR8Cj7Rz3N+Bq4BP4x6RMcbEkGcTtKruU9X3AH87x32gqtsTE5UxxsSOZxO0McYkg4gM\nFpE3RGSTiGwQkR/F61xZ8SrYGGNSVCPwE1V9X0R6AmtEZLmqboz1iTxVgxaRGSJSEd4GJjseY0z6\nUdXdqvp++PExYBMwKB7n8lQNWlXnA/OTHYcxxgCIyFDgfODduJSfrNnscnNzdejQoZ1+v9/vZ9Om\nTQQCAUSEjIwMRo0aRWZmJps3b+aMM86gS5cu7Nu3jz179uD3+/H5fPTq1YtozmuMSbw1a9bsV9W8\naMq4+vLueuBgwNn51tZvAOqa7FqgqguaHiMiPYC3gF+q6p+iia01SatBDx06lPLy8mSd3hjjISIS\ndTfZAwcDrF42xNGxmadvrlPVojbi8QEvAM/EKzmDx5o4jDGmsxQIEoy6HBER4Algk6rOjbrANliC\nNsakBUXxq7MmjnZcDHwXWCciFeF9/6qqS2NReFOWoI0xaSMWNWhV/Rsg0UfTPkvQxpi0oCgBjy3x\nZwnaGJM2gqRoghaRTKAc2Kmq1zZ7LRt4GrgQOABMidX8F6rKjhMbqDz6d7KkC6P7XE5+ztBYFG2M\nSSMKBFI1QQM/IjRipleE124FDqnqMBGZCjwMTIk2OFXllV2lbDzyNn5tQBDeO/hnLs+/mXG5k6It\n3hiTZrxWg3Y01FtECoCvA2WtHDIJeCr8+HngynBXlKh8dmJ9ODnXE2pBCtKoDazct5Bj/oPRFm+M\nSSMK+FUdbW7hdC6OXwP3Qau3QAcBOwBUtRE4AvSPNrjKo+/g14YW+zPIZGuNDXIxxjinKAGHm1u0\nm6BF5Fpgn6quaeuwCPtaXKWI3C4i5SJSXl1d3W5wWeJDIhQtImSJr933G2PMKQoBh5tbOKlBXwxM\nFJHtwLPAFSLy+2bHVAGDAUQkC+hNaMWTz1HVBapapKpFeXntD6sf3edyMqVlM7lqkGE9xzkI3Rhj\nQkIjCZ1tbtFuglbVn6lqgaoOBaYCK1X1O80OWwLcHH48OXxM1L+HBuScyWX53yNTfPgkG5/k4JNs\nrhv8U3Iyu0dbvDEmrQgBh5tbdLoftIg8CJSr6hJC49IXicgWQjXnqTGKj/G53+Tc3hPYWrOGTPEx\nvOc4S87GmA4L3SR0T/J1okMJWlXfBN4MP57VZH8d8K1YBtZUT19/Cvt+NV7FG2PSQKgfdAonaGOM\n8bJgKtegjTHGq6wGbYwxLqUIAW8tw2oJ2hiTPqyJwxhjXEgRGjQz2WF0iCVoY0xaCA1U8VYTh7ei\nNcaYKMRqoIqIXCMiH4nIFhH5abzitRq0MSYtqAoBjb5OGp4bfz7wFULTXLwnIktUdWPUhTdjNWhj\nTNoIIo62dowDtqjqJ6raQGiOorhMUG81aGNMWgjdJIxJyjs1vXJYFTA+FgU3ZwnaGJMWOniTMFdE\nmk46v0BVF4QfO5peORYsQRtj0kbAeT/o/apa1Mprp6ZXDisAdkUTV2ssQRtj0kIMRxK+BwwXkTOB\nnYRm77wpFgU3ZwnaGJM2gjHoxaGqjSJyN7AMyASeVNUNURccgSVoY0xaCE2WFJuOa6q6FFgak8La\nYAnaGJMWFMHvsaHeThaNzRGR1SLyoYhsEJHZEY75vohUi0hFePtBfMI1xpjOUYWAZjja3MJJDboe\nuEJVa0TEB/xNRF5V1VXNjvuDqt4d+xCNMSYWHA1CcZV2E3R48dea8FNfeHPRwuTGGNM+BVfVjp1w\nFK2IZIpIBbAPWK6q70Y47AYRWSsiz4vI4AivIyK3i0i5iJRXV1dHEbYxxnRcgAxHm1s4ikRVA6pa\nSKhD9jgRGd3skD8DQ1V1DLACeKqVchaoapGqFuXl5UUTtzHGdIgiBNXZ5hYd+lWhqocJrep9TbP9\nB1S1Pvz0ceDCmERnjDExooBfsxxtbuGkF0eeiPQJP+4KXAVUNjvm9CZPJwKbYhmkMcZEz9lc0G5a\nWNbJr4rTgafCc6BmAM+p6l9E5EGgXFWXAD8UkYlAI3AQ+H68AjbGmM5QYjOSMJGc9OJYC5wfYf+s\nJo9/BvwstqEZY0xsual27IR7GluMMSaOVMVzNWhvRdtEZWUlxcXFZGdn88gjj7R63LRp0xgxYgSj\nR49m+vTp+P3+BEYZW06v+fXXX+eCCy6gsLCQSy65hC1btiQwSmPcKXSTMNPR5haeTdD9+vWjtLSU\nmTNntnnctGnTqKysZN26ddTW1lJWVpagCGPP6TXfeeedPPPMM1RUVHDTTTcxZ86cBEVojJuJ54Z6\nuyeSDsrPz2fs2LH4fL42jyspKUFEEBHGjRtHVVVVgiKMPafXLCIcPXoUgCNHjjBw4MBEhGeMq4Vu\nEnqrH3TatEH7/X4WLVrEb37zm2SHEndlZWWUlJTQtWtXevXqxapVzadNMSY9uWmUoBPeijYKd911\nF5deeikTJkxIdihx9+ijj7J06VKqqqq45ZZbuPfee5MdkjFJl/IjCZNt/vz5FBYWUlhYyK5dzpcA\nmz17NtXV1cydOzeO0cVHR6+5urqaDz/8kPHjQ4sMT5kyhXfeeSfeYRrjCUEyHG1u4akmjhkzZjBj\nxowOvaesrIxly5bx+uuvk5Hhnv94pzp6zX379uXIkSN8/PHHnHPOOSxfvpyRI0fGMUJjvEEV/MH4\n5wAR+RXwDaAB2ArcEp4mo8O8l7HC9uzZQ0FBAXPnzmXOnDkUFBScujFWUlJyqrZ5xx13sHfvXoqL\niyksLOTBBx9MZthRcXLNWVlZPP7449xwww2cd955LFq0iF/96ldJjtyY5As1cWQ42qK0HBgdnjzu\nY6IYxCeh6Z4Tr6ioSMvLy5NybmOMt4jIGlUtiqaM/HP76+Tff83Rsb+98JmozwcgItcBk1V1Wmfe\n76kmDmOM6ayT3ewSbDrwh86+2RK0MSZNdGiod66INP0Tf4GqLjhVksgK4LQI73tAVV8OH/MAoQnk\nnulkwJagjTHpowNrEu5vq4lDVa9q680icjNwLXClRtGObAnaGJMWQr044j/PhohcA9wPfFlVT0RT\nliVoY0xaODlQJQHmAdnAchEBWKWqd3SmoHYTtIjkAG+HT5gFPK+q/9bsmGzgaUJLXR0Apqjq9s4E\nFEl13Wd8dGw1WeLj3N4X08uXG6uiXSmgjaw7/AF76qoYkDOQL/a+kKwM+11qTLQ60MTRaao6LFZl\nOfnW1wNXqGqNiPiAv4nIq6radIKHW4FDqjpMRKYCDwNTYhHg63ue5t0DSwhqAJEMVu5dxNcH3sV5\nfa+IRfGuc8x/lLkf/YJjjUeoD9aRnZFDt6zu/GTEbHr7+iY7PGM8K0m9OKLS7i1NDakJP/WFt+aN\n3pP450rezwNXSrhuH42dJz5m9YE/06gNBAkQUD+N2sAru/4fJxqPRlu8K71QtYhDDfupD9YBUB+s\n40jDIZ777L+SHJkx3peggSox4ygSEckUkQpgH7BcVd9tdsggYAeAqjYCR4D+0Qa34chf8WtDy3jI\nYPOx96It3pXWHi4nQOBz+4IEWX+kgmQNKjImFagKjZrhaHMLR5GoakBVC4ECYJyIjG52SKTacots\nIiK3i0i5iJRXV1d3PFpjjIlCSs9mF57w403gmmYvVQGDAUQkC+hNaHXv5u9foKpFqlqUl5fX7vlG\n9Z6AT7q0jIMgw3uO7UjonnFenyIy+XxXoAwyGN27kBi0GhmTtrw4YX+7CVpE8kSkT/hxV+AqoLLZ\nYUuAm8OPJwMro+mcfdKgbucwrv83yJIuZJBJpvjIki58feBddMvqFW3xrnR9wXfp26U/2Rk5gJCd\nkUNvX19uHHJLskMzxvO8lqCd9OI4HXhKRDIJJfTnVPUvIvIgUK6qS4AngEUisoVQzXlqrAK88rTv\n8cU+l/FxmnSz6+nrxf8a9SvrZmdMjCWwH3TMtPutV9W1wPkR9s9q8rgO+FZsQ/un/Jwh5OcMiVfx\nrpMpWRT2HQukZjOOMcmSiH7QsWTVMmNMWlCFxgRM2B9LlqCNMWkj5Zo4jDEmFaRkG7QxxqQKtQRt\njDHuZDcJjTHGhVStDdoYY1xKCFgvDmOMcSevtUF769eJMcZ0UqLn4hCRmSKiItLpoc9WgzbGpAcN\ntUMngogMBr4CfBZNOVaDNsakjSDiaIuBR4H7iDDtckdYDdoYkxY0QTcJRWQisFNVP4x2imBL0MaY\ntNGBJo5cESlv8nyBqi44+UREVgCnRXjfA8C/Al/tbIxNWYI2xqSNDvTi2K+qRa2Xo1dF2i8iXwTO\nBE7WnguA90VknKru6WC4lqCNMelBNf7d7FR1HZB/8rmIbAeKVHV/Z8qzBG2MSRteG0noZMmrwSLy\nhohsEpENIvKjCMdcJiJHRKQivM2KVJYxxiSTqrMtdufToZ2tPYOzGnQj8BNVfV9EegJrRGS5qm5s\ndtxfVfXazgZijDHxpAhBjw31bjdaVd2tqu+HHx8DNgGD4h2YMcbEmjrc3KJDv05EZCih9QnfjfBy\nsYh8KCKvisioGMRmjDGxE75J6GRzC8c3CUWkB/AC8GNVPdrs5feBM1S1RkRKgJeA4RHKuB24HWDI\nkPRZBNYY4xJuqh474KgGLSI+Qsn5GVX9U/PXVfWoqtaEHy8FfJEmCFHVBapapKpFeXl5UYZujDEd\nk3I1aAn1tn4C2KSqc1s55jRgr6qqiIwjlPgPxDRSY4yJggLBoHuSrxNOmjguBr4LrBORivC+fwWG\nAKjqY8Bk4E4RaQRqgamqiZo3yhhjHFDARbVjJ9pN0Kr6N2h7eidVnQfMi1VQxhgTD16rNtpIQmNM\n+vBYgvZWr+2w1157jREjRjBs2DAeeuihVo97/vnnERHKy8tbPcZLKisrKS4uJjs7m0ceeaTV46ZN\nm8aIESMYPXo006dPx+/3JzDK2HJ6zdu2bWP8+PEMHz6cKVOm0NDQkMAojTc4u0HoppuEnkvQgUCA\nGTNm8Oqrr7Jx40YWL17Mxo3NBzXCsWPHKC0tZfz48UmIMj769etHaWkpM2fObPO4adOmUVlZybp1\n66itraWsrCxBEcae02u+//77ueeee9i8eTN9+/bliSeeSFCExlM8NlLFcwl69erVDBs2jLPOOosu\nXbowdepUXn755RbH/fznP+e+++4jJycnCVHGR35+PmPHjsXn87V5XElJCSKCiDBu3DiqqqoSFGHs\nOblmVWXlypVMnjwZgJtvvpmXXnopUSEar1DQoDja3MJzCXrnzp0MHjz41POCggJ27tz5uWM++OAD\nduzYwbXXpvfUIH6/n0WLFnHNNdckO5S4OnDgAH369CErK3RLJdLPhDEh4nBzB8/dJIzUe6/psjLB\nYJB77rmHhQsXJjAqd7rrrru49NJLmTBhQrJDiav2fiaMOcVFzRdOeK4GXVBQwI4dO049r6qqYuDA\ngaeeHzt2jPXr13PZZZcxdOhQVq1axcSJEz17o3D+/PkUFhZSWFjIrl27HL9v9uzZVFdXM3duxLFF\nrtbRa87NzeXw4cM0NjYCLX8mjDnF2qDja+zYsWzevJlt27bR0NDAs88+y8SJE0+93rt3b/bv38/2\n7dvZvn07F110EUuWLKGoqNXVa1xtxowZVFRUUFFR4TjplJWVsWzZMhYvXkxGhuc+4g5fs4hw+eWX\n8/zzzwPw1FNPMWnSpHiHabzm5EAVJ5tLeO7bm5WVxbx587j66qsZOXIkN954I6NGjWLWrFksWbIk\n2eHF1Z49eygoKGDu3LnMmTOHgoICjh4NzVtVUlJyqrZ5xx13sHfvXoqLiyksLOTBBx9MZthRcXrN\nDz/8MHPnzmXYsGEcOHCAW2+9NZlhG5dK9IT90ZJkjcguKipSrzY7GGMSS0TWtLWIqxPZQwv0tP/V\nYkGoiD677b6ozici/wLcTWjBk1dU9b7OlOO5m4TGGNNZkoD6qIhcDkwCxqhqvYjkt/ee1liCNsak\nh8TdALwTeEhV6wFUdV9nC/JcG7QxxnSOwxuE0d8kPAeYICLvishbIjK2swVZDdoYkz6c16BzRaTp\nTbIFqrrg5BMRWQGcFuF9DxDKq32Bi4CxwHMiclZnpmC2BG2MSR9Bx0fub+smoape1dprInIn8Kdw\nQl4tIkEgF6juQKSAgyYOERksIm+IyCYR2SAiLW6DSkipiGwRkbUickFHA2lLfeNedh/7I3trXqYx\n0Hw5xNSjqnx6fD3lB19lW83aiCPlUk194Dgbj7zBh4de46i/wz/HxrQvcf2gXwKuABCRc4AuwP7O\nFOSkBt0I/ERV3xeRnsAaEVmuqk2nkPsaoUVihwPjgd+G/43ajiP/xfbDc4EMBOFjZnFu3q/p3+3y\nWBTvOvWBEzy97QEONOwkqEEyJIM+vgHcfNZ/0DWzR7LDi4vtNR/w4o4HERFUgwRRvpT7bYrzpiY7\nNJNiEtGLA3gSeFJE1gMNwM2dXWGq3Rq0qu5W1ffDj48Bm4BBzQ6bBDytIauAPiJyemcCaqqmoZLt\nhx8lqPUEtZaAniCotWys/jGNwWPRFu9Ky/f8F/vqP6UhWEejNtAQrGN//U5e3fW7ZIcWFw3BOl6s\n+t/4tY6GYC1+rSegDfxj/7Psrv0o2eGZVJOAod6q2qCq31HV0ap6gaqu7GxZHerFISJDgfOBd5u9\nNAjY0eR5FS2TeIftq1lCUFtOvC4IB068EW3xrrTuyFsEtPFz+4I0suno31OyqWN7zRokwuxhAW1g\n3eHlSYjIGPdwnKBFpAfwAvBjVW3eEByp0aZFNhGR20WkXETKq6vbb2cMJeeWSUnRiIk7FQQ10Mr+\nIK6axSVGAupHW/mMA8HU/IxN8og629zCUYIWER+h5PyMqv4pwiFVwOAmzwuAFtOQqeoCVS1S1aK8\nvLx2z5vb/atkSMsJ91UD9Ot6qZPQPWdYjwuQZh+LIJzZfQwiqddtfWj3Cwg2+4sBwCc5jOidmp+x\nSRIFguJscwknvTgEeALYpKqtzV25BPheuDfHRcARVd0dbXC9s8eS372EDOlKqJKeSYbkcFbfmWRn\ndXr0pKtdc/rtdMvqhU+yAfBJNl0ze/L1QXclObL46JrViysH3EGWdEHIBASf5HB2z/Gc2f3CZIdn\nUo3Hpht10ovjYuC7wDoRqQjv+1dgCICqPgYsBUqALcAJ4JZYBCcinNP/3xnQ43r2H19GhmST32Mi\nPbqMiEXxrtS7Sx7/Mvx3rDv8FnvqPiE/5wzG9Lmc7MxuyQ4tbgr7lTC4+2g2HH6dhmAdw3sVM6Tb\neTbpvok5NzVfONFuglbVv9HOGjDhLiQzYhVUUyJCn5yx9Mnp9GhJz+mS2ZUL+6f2MlXN9c8ewqUD\nYvJ73ZjWpVqCNsaYlGEJ2hhj3MdtPTScsARtjEkfLuqh4YQlaGNM2rAatDHGuJUlaGOMcSFrgzbG\nGBezBG2MMe4kzifsd4XUm9zBGGNShNWgjTHpw2NNHFaDNsakB4dTjUZ7I1FECkVklYhUhKdXHtfZ\nsixBG2PSR2Jms/tPYLaqFgKzws87xZo4jDHpIzFNHAr0Cj/uTYS58Z2yBG2MSQtCwnpx/BhYJiKP\nEGql+FJnC7IEbYxJDx1rX84VkfImzxeo6oKTT0RkBXBahPc9AFwJ3KOqL4jIjYQWPLmqMyFbgjbG\npA/nCXq/qha1WoxqqwlXRJ4GfhR++kegzPFZm3Gy5NWTIrJPRNa38vplInIkfMeyQkRmdTYYY4yJ\nq8TcJNwFfDn8+Apgc2cLclKDXgjMA55u45i/quq1nQ3CGGMSIUFzcdwG/EZEsoA64PbOFuRkyau3\nRWRoZ09gjDGukYAEHV4mMCYrHseqH3SxiHwoIq+KyKgYlWmMMbGjoV4cTja3iMVNwveBM1S1RkRK\ngJeA4ZEOFJHbCVf3hwwZEoNTG2NMB6TbUG9VPaqqNeHHSwGfiOS2cuwCVS1S1aK8vLxoT22MMR2S\niKHesRR1ghaR00REwo/Hhcs8EG25xhgTc4npxREz7TZxiMhi4DJCHbergH8DfACq+hgwGbhTRBqB\nWmCqqrroEo0xBtclXyec9OL4djuvzyPUDc8YY1xLcFfzhRM2ktAYkza8lqA9O91oZWUlxcXFZGdn\n88gjj7R63LZt2xg/fjzDhw9nypQpNDQ0JDDK2HJ6zarKAw88wDnnnMPIkSMpLS1NYJSx5fSap02b\nxogRIxg9ejTTp0/H7/cnMMrYcXq9r7/+OhdccAGFhYVccsklbNmyJYFRepjH2qA9m6D79etHaWkp\nM2fObPO4+++/n3vuuYfNmzfTt29fnnjiiQRFGHtOr3nhwoXs2LGDyspKNm3axNSpUxMUYew5veZp\n06ZRWVnJunXrqK2tpays09MfJJXT673zzjt55plnqKio4KabbmLOnDkJitDjLEEnRn5+PmPHjsXn\n87V6jKqycuVKJk+eDMDNN9/MSy+9lKgQY87JNQP89re/ZdasWWRkZJx6n1c5veaSkhJEBBFh3Lhx\nVFVVJSjC2HJ6vSLC0aNHAThy5AgDBw5MRHjelqAVVWIppdugDxw4QJ8+fcjKCl1mQUEBO3fuTHJU\n8bd161b+8Ic/8OKLL5KXl0dpaSnDh0ccO5Ry/H4/ixYt4je/+U2yQ4mrsrIySkpK6Nq1K7169WLV\nqlXJDskbXJR8nfBsDdqJSL39wl22U1p9fT05OTmUl5dz2223MX369GSHlDB33XUXl156KRMmTEh2\nKHH16KOPsnTpUqqqqrjlllu49957kx2SJ3htqLenEvT8+fMpLCyksLCQXbvaX0UmNzeXw4cP09jY\nCEBVVZXn/hTs6DVD6C+FG264AYDrrruOtWvXxjPEmOvMNQPMnj2b6upq5s6dG8foYq+j11tdXc2H\nH37I+PHjAZgyZQrvvPNOvMNMCV5r4vBUgp4xYwYVFRVUVFQ4SrQiwuWXX87zzz8PwFNPPcWkSZPi\nHWZMdfSaAb75zW+ycuVKAN566y3OOeeceIYYc5255rKyMpYtW8bixYtPtb17RUevt2/fvhw5coSP\nP/4YgOXLlzNy5Mh4h+l9Tm8QuihBS7IG/RUVFWl5eXn7B7Ziz549FBUVcfToUTIyMujRowcbN26k\nV69elJSUUFZWxsCBA/nkk0+YOnUqBw8e5Pzzz+f3v/892dnZMbySxHF6zYcPH2batGl89tln9OjR\ng8cee4zzzjsv2eF3itNrzsrK4owzzqBnz54AXH/99cya5b21I5xe74svvnjqRnDfvn158sknOeus\ns5IdftyIyJq2VjhxolveYP3C9c6agj5YcG/U54sFzyZoY0z6iEWC7p43WL9wnbME/f7j7kjQKd2L\nwxhjmpKgi9ovHPBWY50xxnRWgtqgReRbIrJBRIIiUtTstZ+JyBYR+UhErm6vLKtBG2PSRoJ6aKwH\nrgd+97lzi5wLTAVGAQOBFSJyjqoGWivIatDGmPSRgBq0qm5S1Y8ivDQJeFZV61V1G7AFGNdWWZag\njTFpI8n9oAcBO5o8rwrva1W7CVpEnhSRfSKyvpXXRURKw+0qa0Xkgg6F7EB94Dibj/2DT2rKaQx6\ndza6jthTV8WHh1exu/azZIeSEAFtZOuxD6g8uoq6QE2yw0mIIw2HqDi0mq01HxFUFw1fS2XOa9C5\nIlLeZLu9aTEiskJE1kfY2hpoEWkYc5u/Dpy0QS8kNCH/0628/jVCi8QOB8YDvw3/GxMbDr/Ost3/\nlwzJBEAQrh/8CwZ3Hx2rU7iKP9jAwm2P8MnxTWRIJkENMKTbMKafeT/ZmTnJDi8uqk58xOJPZxPU\nACAEtJGrT7+NC/u1ew/Fk1SVF3c+w1+rV5AlWShKj6ye/MvwB+ifbWt1xo12aBj3/ra62anqVZ2I\noAoY3OR5AdDm0NF2a9Cq+jZwsI1DJgFPa8gqoI+InO4g2HYdrK9i2e5SGrWehuAJGoInqA8e54Ud\ns2gI1sXiFK6zdPdith7fiF8bqA/W4tcGPj2xmT/vau33o7c1Bv389/ZfUBuooT5YS33wBI3awLLd\nj7O3bluyw4uLisOr+fv+lTSqn7pgLfXBOg427GfBVm8NUfeakyuqJLGJYwkwVUSyReRMQpXa1W29\nIRZt0B1uV3Fq/eEV4VrV56nC1mPvxuIUrvPewTdp1M9PNt+ofsoPvR1x8iev21rzAUFaVmsC2sgH\nB1ckIaL4e2vfMhqC9Z/bpyjV9XvYV7cnSVGlCVVnWxRE5Lrw+q3FwCsisix0at0APAdsBF4DZrTV\ngwNi083OcbtKuB3ndoAhQ4a0W3Bd8DhBIiRogjQEazsWpUf4tT7i/oA2oigS8b/buxqCJyJ+IZQg\ndcHUbIuua+VnN0MyqE/Rn2u3SEQ3O1V9EXixldd+CfzSaVmxqEE7bldR1QWqWqSqRXl57be1De95\nET5p2e6qBBna/fxOhutuZ3cfFTEJD+0+ggxJvU43Q7uPIRDhl7AvI4cv9CpOQkTxV9hnHFnSckL+\nDMlgYNfBEd5hYsKDkyXF4hu/BPheuDfHRcARVd0dg3IZ2v18zuhe2CRJCz7JZlz/yfTuMiAWp3Cd\n6wpuISez66kvcJb4yMnoyvWDbk1yZPHR09ePL+dNxSfZnPxjzCc5DO76Bc7pOTa5wcXJl/Ovpl+X\nXLpkhCbtyiADn3ThpiG3kSk2diyevDYfdLs/DSKyGLiMULeTKuDfAB+Aqj4GLAVKCHW6PgHcEqvg\nRDK4bvDP2XzsH2w88iZZGdl47SUqAAAPGElEQVSM6fNVhnQfE6tTuE5e9kDuG/FrVh1YwY7arQzM\nOYMv5X6VXr6+yQ4tbi7J/xZDuo/ig0PLaQjWcm7vSxjZq/hUz51U0zWzG/eP/CWrD/yVjUc/pE+X\n/kzIvYrTuxYkO7SU56bk64TNZmeMcb1YzGbXo+9gPe/KHzk69p0X/qfNZmeMMYnkptVSnLAEbYxJ\nH5agjTHGfU4OVPESS9DGmPSg6rkJ+y1BG2PSh7fysyVoY0z6sCYOY4xxIwWsicMYY1zKW/nZErQx\nJn1YE4cxxriU9eIwxhg3ctlMdU5YgjbGpIXQQBVvZWhL0MaY9OGx2exSbwZ4Y4xphag62qI6h8i3\nRGSDiARFpKjJ/q+IyBoRWRf+94r2yrIatDEmPSSuDXo9cD3wu2b79wPfUNVdIjIaWEY767dagjbG\npInEzMWhqpsARKT5/g+aPN0A5IhItmorC5HisIlDRK4RkY9EZIuI/DTC698XkWoRqQhvP3B0JcYY\nk0jOV/XOFZHyJtvtMY7kBuCDtpIzOFvyKhOYD3yF0AKx74nIElXd2OzQP6jq3Z2N1hhj4ko7tOTV\n/rZWVBGRFcBpEV56QFVfbqtgERkFPAx8tb0gnDRxjAO2qOon4cKfBSYBzRO0Mca4W4y62anqVZ15\nn4gUAC8C31PVre0d76SJYxCwo8nzKiI3bN8gImtF5HkRsbXjjTHuow63OBCRPsArwM9U9e9O3uMk\nQUuEfc0v4c/AUFUdA6wAnmolwNtPtulUV1c7ic8YY2JGgkFHW1TnELlORKqAYuAVEVkWfuluYBjw\n8yb36/LbKstJE0cV0LRGXADsanqAqh5o8vRxQu0rLajqAmABhFb1dnBuY4yJDSUhA1VU9UVCzRjN\n988B5nSkLCc16PeA4SJypoh0AaYCS5oeICKnN3k6EdjUkSCMMSbeBGeDVNw0HLzdGrSqNorI3YQ6\nVWcCT6rqBhF5EChX1SXAD0VkItAIHAS+H8eYjTGmc1yUfJ1wNFBFVZcCS5vtm9Xk8c+An8U2NGOM\nibFUTNDGGON5CWqDjiVL0MaYtBFtD41E8+Rsdq+99hojRoxg2LBhPPTQQy1eX7hwIXl5eRQWFlJY\nWEhZWVkSooy9yspKiouLyc7O5pFHHmn1uHnz5jFs2DBEhP379ycwwthp7zN+7LHH+OIXv0hhYSGX\nXHIJGzemxrgpp5/xtGnTGDFiBKNHj2b69On4/f4ERhlbTq9ZQn4pIh+LyCYR+WHHzuRwmLeLmkE8\nl6ADgQAzZszg1VdfZePGjSxevDjil3PKlClUVFRQUVHBD36QGlOD9OvXj9LSUmbOnNnmcRdffDEr\nVqzgjDPOSFBkseXkM77ppptYt24dFRUV3Hfffdx7771Jija2nH7G06ZNo7KyknXr1lFbW+vpSojT\naybU+WAw8AVVHQk826ETKZag42316tUMGzaMs846iy5dujB16lRefrnNoe8pIz8/n7Fjx+Lz+do8\n7vzzz2fo0KGJCSoOnHzGvXr1OvX4+PHjLWYO8yqnn3FJSQkigogwbtw4qqqqEhRh7Dm9ZuBO4EFV\nDQKo6r4OnyzocHMJzyXonTt3MnjwP8fNFBQUsHPnzhbHvfDCC4wZM4bJkyezY8eOFq8b93L6Gc+f\nP5+zzz6b++67j9LS0kSG6Bp+v59FixZxzTXXJDuURDgbmBIejfyqiAzvaAFe6wftuQStEf7zmtee\nvvGNb7B9+3bWrl3LVVddxc0335yo8EwMOPmMAWbMmMHWrVt5+OGHmTOnQwO0UsZdd93FpZdeyoQJ\nE5IdSiJkA3XhWeYeB57scAnWxBFfBQUFn6sRV1VVMXDgwM8d079/f7KzswG47bbbWLNmTUJjjKX5\n8+efutm5a9eu9t+QApx8xk1NnTqVl156KRGhxUVnP+PZs2dTXV3N3Llz4xhdfHTymquAF8KPXwTG\ndOikqhAIOttcwnMJeuzYsWzevJlt27bR0NDAs88+y8SJEz93zO7du089XrJkCSNHjkx0mDEzY8aM\nUzc720pSqcTJZ7x58+ZTj1955RWGD+/wX7uu0ZnPuKysjGXLlrF48WIyMjz3Ne7sz/VLwMl1/L4M\nfNzhE1sNOr6ysrKYN28eV199NSNHjuTGG29k1KhRzJo1iyVLQlOElJaWMmrUKM477zxKS0tZuHBh\ncoOOkT179lBQUMDcuXOZM2cOBQUFHD16FAjdNDpZEyktLaWgoICqqirGjBnjuV4sTj7jefPmMWrU\nKAoLC5k7dy5PPRVxAkXPcfoZ33HHHezdu5fi4mIKCwt58MEHkxl2VJxeM/AQoWmN1wH/AXT8B9tj\nCVoitfclQlFRkZaXlyfl3MYYbxGRNW2tcOJE7+zT9EuDvuPo2Ne2/Z+ozxcLNpLQGJMmFNQ97ctO\nWII2xqQHxVU3AJ3wXBu0McZ0WgLaoEXkWyKyQUSCItKimUREhohIjYi0O3TSErQxJn0k5ibheuB6\n4O1WXn8UeNVJQY4StIhcIyIficgWEflphNezReQP4dffFZGhTsp1KqgNHK1bQ039OtRjbUidVeM/\nyGfH13HM783JjjpKVTlWv5HDdWsIakOyw0mI+sAJPj2+nv313h2m3VHV9bv5pGYjtYHjSTh7YiZL\nUtVNqvpRpNdE5JvAJ8AGJ2W12wYtIpnAfOArhDqKvyciS1S16ew1twKHVHWYiEwltCbhFCcBtOfg\niZVs3n8PoChBsjJ6MTK/jO5dzo1F8a4T0EaW7vo1m47+lSzx0ah+hve4iIkFM8mUducq8KSahs2s\n3fs/8AcPcbLOMDL338nvfnVyA4ujd6r/xJv7/ptMySKgjeTnDGHqGT+nR1bfZIcWF8cbj/HUtofZ\nWbuNTMmiUf1clv9NvjLgW4mbR0WBJE43KiLdgfsJ5dJ2mzfAWQ16HLBFVT9R1QZCM0hNanbMJP65\nkvfzwJUSg//1usadfLz/bgJ6jIDWENQTNAT2sGHvdwhqfbTFu9LfqxdTefTvBNRPffAEAfWzpeZd\n3ty7MNmhxUVQ/Xyw52bqAjsJ6AkCWkNAa9i4/z5O+LclO7y42HysnLf2LaZRG6gPnqBRG9hTu43n\nPv2PZIcWN898+ig7TmzBrw3UBU/QqH7e3reEdUdWJTYQ5zXo3PCcHye325sWIyIrRGR9hK15bmxq\nNvCoqtY4DddJL45BQNPZhqqA8a0dE17D8AjQH4jq7/N9NX9ENdBif1D9HKp9g/7dUm+CmDUH/0Jj\ns18+jdrAB4de5YoBP0iZWdtOOlT7DkGta7E/qI3sPPYcw/vdn4So4mvV/pfxN/uMgwTYU/cJhxv2\n0qfLgCRFFh/H/IfZfrySAJ//LjdoPW9V/5kxfYoTFIl2pBfH/rb6QavqVZ0IYDwwWUT+E+gDBEWk\nTlXntfYGJwk6UkZo3kjj5BjCv4VuBxgyZEi7J/YHDqBEmog8iD9wqN33e1FD8ETE/aEvtBL5v9q7\n/MHDRPhRARppCKRm+/vxxiMR92dIJicCx+hDaiXo2sBxMiQTtOV3+UTj0cQFoiT1HpaqnprRSkR+\nAdS0lZzBWRNHFaFJsk8qAJrPbnLqGBHJAnoTWt27eYALVLVIVYvy8vLaPXGfrhPIkG4t9itBeuc0\nr8SnhkHdvhBx/2k5ZyOSep1ueucUobT8KylTutG/65eTEFH8De95Yav3E/Kz26+4eE3/7NPIlMwW\n+zPIZETP8xMbTFCdbVEQketEpAooBl4RkWWdLcvJN/49YLiInCkiXYCpwJJmxywBTs7pORlYqTEY\nQ96v65V07zKKDOn6z4ClG/ndr6er76xoi3elr5x2B76MHDII/UALmfgkh6tPn5HkyOKja9YgBvX8\ndrPPuCvdfGen7E3C4tzr6JbZi6xTSVrwSTZXn/YDsjK6JDW2eMiUTK4bdBs+6YKE/wLMFB/dsnpw\nxYDrExtMYnpxvKiqBaqaraoDVLXFD7Kq/kJVW1/fK6zdJo5wm/LdwDIgE3hSVTeIyINAuaouAZ4A\nFonIFkI156kdvahIRDIZNWAR+479keoTL5MhOQzoMZX+3b4Wi+JdaUDO2dx61nzePfACe2q3MCDn\nLMb1v57+2QXJDi1uhvX9KX1yxrLz6GICeoIB3a/l9B6TyUjRXivdsnpxx7BSVh/4C1tq1tDLl8v4\n/hMZ0j01eyYBFPa9mH7Z+by9788catjP8J5f5JK8Enpk9U5cEKpJ7cXRGTZZkjHG9WIyWVJmrhZ3\n/4ajY5cdW2iTJRljTOIoGmh5v8PNLEEbY9KDEvUNwESzBG2MSR8emyrCErQxJi0ooFaDNsYYF1Kb\nsN8YY1zLazcJk9bNTkSqgU87+LZcopzfw4PS7ZrT7Xoh/a65M9d7hqq2P/y4DSLyWvjcTuxX1aRP\n9pO0BN0ZIlLuhr6JiZRu15xu1wvpd83pdr3RSL3JHYwxJkVYgjbGGJfyWoJekOwAkiDdrjndrhfS\n75rT7Xo7zVNt0MYYk068VoM2xpi04YkE3d6q4qlGRJ4UkX0isj7ZsSSKiAwWkTdEZJOIbBCRHyU7\npngSkRwRWS0iH4avd3ayY0oUEckUkQ9E5C/JjsXtXJ+gm6wq/jXgXODbIpK6E+eGLASS3gczwRqB\nn6jqSOAiYEaKf871wBWqeh5QCFwjIhclOaZE+RGwKdlBeIHrEzTOVhVPKar6NhGWDEtlqrpbVd8P\nPz5G6As8KLlRxY+GnFzd2RfeUv6GkIgUAF8HypIdixd4IUFHWlU8Zb+4BkRkKHA+8G5yI4mv8J/6\nFcA+YLmqpvT1hv0auA/w1qQYSeKFBO1oxXCTGkSkB/AC8GNVTeCSz4mnqgFVLSS0EPM4ERmd7Jji\nSUSuBfap6ppkx+IVXkjQTlYVNylARHyEkvMzqvqnZMeTKKp6GHiT1L/vcDEwUUS2E2qqvEJEfp/c\nkNzNCwnayarixuNERAgtPrxJVecmO554E5E8EekTftwVuAqoTG5U8aWqPwuvdj2U0Pd4pap+J8lh\nuZrrE7SqNgInVxXfBDynqhuSG1V8ichi4B/ACBGpEpFbkx1TAlwMfJdQraoivJUkO6g4Oh14Q0TW\nEqqELFdV63ZmPsdGEhpjjEu5vgZtjDHpyhK0Mca4lCVoY4xxKUvQxhjjUpagjTHGpSxBG2OMS1mC\nNsYYl7IEbYwxLvX/AcRnoY4TI7qLAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f7f41cd8240>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj_mexp = mexp.with_coeffs(expansion_mat @ reduction_mat @ mexp.coeffs)\n",
     "\n",
     "proj_resid = proj_mexp.coeffs - mexp.coeffs\n",
     "\n",
-    "plot_coeffs(mpole_expn, np.log10(1e-15+np.abs(proj_resid)), vmin=-15, vmax=2)"
+    "plot_coeffs(mpole_expn, np.log10(1e-15 + np.abs(proj_resid)), vmin=-15, vmax=2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.80866677486e-15\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(t.l_inf(proj_mexp - mexp, 1.2, center=[3,0]))"
+    "print(t.l_inf(proj_mexp - mexp, 1.2, center=[3, 0]))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0116062369243\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "trans_unproj = t.multipole_expand(mexp, new_center)\n",
     "trans_proj = t.multipole_expand(proj_mexp, new_center)\n",
     "\n",
-    "print(t.l_inf(trans_unproj - trans_proj, 1.2, center=[3,0]))"
+    "print(t.l_inf(trans_unproj - trans_proj, 1.2, center=[3, 0]))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[-3.07295099 -0.08541702 -1.62768408 -2.17149444 -0.06559717 -2.66984178\n",
-      " -0.05931738 -1.14908652 -0.08143883 -1.25881949 -0.02604215 -0.04555359\n",
-      " -0.40284643 -0.05019419 -0.39528495]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(trans_proj.coeffs - trans_unproj.coeffs)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.1169116976203841"
-      ]
-     },
-     "execution_count": 75,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "la.norm(reduction_mat @ (trans_proj.coeffs - trans_unproj.coeffs))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.011804658035654577"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "t.l_inf(trans_unproj - pt_src, 1.2, center=[3, 0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.00029429326299543407"
-      ]
-     },
-     "execution_count": 77,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "t.l_inf(mexp - pt_src, 1.2, center=[3, 0])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -439,9 +308,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4+"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/contrib/translations/PDE-reduction-symbolic.ipynb
+++ b/contrib/translations/PDE-reduction-symbolic.ipynb
@@ -6,20 +6,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pyopencl as cl\n",
-    "import sumpy.toys as t\n",
-    "import numpy as np\n",
-    "import numpy.linalg as la\n",
-    "import matplotlib.pyplot as plt\n",
-    "from sumpy.visualization import FieldPlotter\n",
-    "from pytools import add_tuples\n",
+    "from __future__ import annotations\n",
     "\n",
     "from sumpy.expansion.local import VolumeTaylorLocalExpansion\n",
-    "from sumpy.expansion.multipole import VolumeTaylorMultipoleExpansion, LinearPDEConformingVolumeTaylorMultipoleExpansion\n",
-    "                                           \n",
-    "from sumpy.kernel import (YukawaKernel, HelmholtzKernel, LaplaceKernel)\n",
-    "\n",
+    "from sumpy.expansion.multipole import (\n",
+    "    LaplaceConformingVolumeTaylorMultipoleExpansion,\n",
+    "    LinearPDEConformingVolumeTaylorMultipoleExpansion,\n",
+    "    VolumeTaylorMultipoleExpansion,\n",
+    ")\n",
+    "from sumpy.kernel import HelmholtzKernel, LaplaceKernel, YukawaKernel  # noqa: F401\n",
     "from sumpy.symbolic import make_sym_vector\n",
+    "\n",
     "\n",
     "order = 2\n",
     "dim = 2\n",
@@ -28,16 +25,16 @@
     "    knl = LaplaceKernel(dim)\n",
     "    extra_kernel_kwargs = {}\n",
     "    mpole_expn_reduced_class = LaplaceConformingVolumeTaylorMultipoleExpansion\n",
-    "    \n",
+    "\n",
     "else:\n",
     "    helm_k = 1.2\n",
     "    knl = HelmholtzKernel(dim)\n",
-    "    extra_kernel_kwargs={\"k\": helm_k}\n",
+    "    extra_kernel_kwargs = {\"k\": helm_k}\n",
     "    mpole_expn_reduced_class = LinearPDEConformingVolumeTaylorMultipoleExpansion\n",
     "\n",
     "mpole_expn_reduced = mpole_expn_reduced_class(knl, order)\n",
     "mpole_expn = VolumeTaylorMultipoleExpansion(knl, order)\n",
-    "local_expn = VolumeTaylorLocalExpansion(knl, order)\n"
+    "local_expn = VolumeTaylorLocalExpansion(knl, order)"
    ]
   },
   {
@@ -49,8 +46,12 @@
     "reduced_wrangler = mpole_expn_reduced.expansion_terms_wrangler\n",
     "full_wrangler = mpole_expn.expansion_terms_wrangler\n",
     "\n",
-    "reduced_derivatives = list(make_sym_vector(\"deriv\", len(reduced_wrangler.stored_identifiers)))\n",
-    "full_derivatives = reduced_wrangler.get_full_kernel_derivatives_from_stored(reduced_derivatives, 1)\n",
+    "reduced_derivatives = list(\n",
+    "    make_sym_vector(\"deriv\", len(reduced_wrangler.stored_identifiers))\n",
+    ")\n",
+    "full_derivatives = reduced_wrangler.get_full_kernel_derivatives_from_stored(\n",
+    "    reduced_derivatives, 1\n",
+    ")\n",
     "\n",
     "print(reduced_derivatives)\n",
     "print(full_derivatives)"
@@ -62,9 +63,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "full_coeffs = list(make_sym_vector(\"coeff\", len(reduced_wrangler.get_full_coefficient_identifiers())))\n",
+    "full_coeffs = list(\n",
+    "    make_sym_vector(\"coeff\", len(reduced_wrangler.get_full_coefficient_identifiers()))\n",
+    ")\n",
     "\n",
-    "reduced_coeffs = reduced_wrangler.get_stored_mpole_coefficients_from_full(full_mpole_coefficients=full_coeffs, rscale=1)\n",
+    "reduced_coeffs = reduced_wrangler.get_stored_mpole_coefficients_from_full(\n",
+    "    full_mpole_coefficients=full_coeffs, rscale=1\n",
+    ")\n",
     "\n",
     "print(full_coeffs)\n",
     "print(reduced_coeffs)"
@@ -77,7 +82,9 @@
    "outputs": [],
    "source": [
     "dvec = make_sym_vector(\"d\", dim)\n",
-    "translated_reduce_coeffs = mpole_expn_reduced.translate_from(mpole_expn_reduced, reduced_coeffs, 1, dvec, 1)\n",
+    "translated_reduce_coeffs = mpole_expn_reduced.translate_from(\n",
+    "    mpole_expn_reduced, reduced_coeffs, 1, dvec, 1\n",
+    ")\n",
     "translated_full_coeffs = mpole_expn.translate_from(mpole_expn, full_coeffs, 1, dvec, 1)\n",
     "translated_full_coeffs"
    ]
@@ -88,10 +95,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eval_reduced = sum(a*b for a, b in zip(translated_reduce_coeffs, reduced_derivatives))\n",
-    "eval_full = sum(a*b for a, b in zip(translated_full_coeffs, full_derivatives))\n",
+    "eval_reduced = sum(a * b for a, b in zip(translated_reduce_coeffs, reduced_derivatives))\n",
+    "eval_full = sum(a * b for a, b in zip(translated_full_coeffs, full_derivatives))\n",
     "\n",
-    "(eval_full-eval_reduced).simplify()"
+    "(eval_full - eval_reduced).simplify()"
    ]
   }
  ],
@@ -111,7 +118,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
ruff 0.5.6 started linting notebooks by default too (under the `preview` flag at least). This fixes all reported issues in the `contrib/translations` notebooks.