### PR TITLE
Make sympy a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "numpy",
     "pyopencl>=2022.1",
     "pytools>=2022.1",
+    "sympy>=0.7.2",
 ]
 
 [project.optional-dependencies]
@@ -48,9 +49,6 @@ doc = [
 ]
 fmmlib = [
     "pyfmmlib>=2023.1",
-]
-sympy = [
-    "sympy>=0.7.2",
 ]
 symengine = [
     "symengine>=0.9.0",


### PR DESCRIPTION
This was mistakenly made optional in #207.

The other dependencies there should be legitimately optional (`fmmlib`, `symengine` and `pyvkfft`).