### PR TITLE
Add custom __repr__ for Kernel

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -33594,6 +33594,14 @@
                 }
             },
             {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 19,
@@ -36488,38 +36496,6 @@
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
                     "startColumn": 12,
                     "endColumn": 26,
                     "lineCount": 1
@@ -36546,22 +36522,6 @@
                 "range": {
                     "startColumn": 14,
                     "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -54378,6 +54338,22 @@
                 "range": {
                     "startColumn": 13,
                     "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -219,6 +219,20 @@ class Kernel(ABC):
     def is_complex_valued(self) -> bool:
         """A boolean flag indicating whether this kernel is complex valued."""
 
+    @override
+    def __repr__(self) -> str:
+        from dataclasses import fields
+
+        args: list[str] = []
+        for f in fields(self):
+            value = getattr(self, f.name)
+            if isinstance(value, prim.ExpressionNode):
+                args.append(f"{f.name}={value}")
+            else:
+                args.append(f"{f.name}={value!r}")
+
+        return f"{type(self).__name__}({', '.join(args)})"
+
     def get_base_kernel(self) -> Kernel:
         """
         :returns: the kernel being wrapped by this one, or else *self*.
@@ -381,7 +395,7 @@ class Kernel(ABC):
 # }}}
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class ExpressionKernel(Kernel, ABC):
     r"""
     .. autoattribute:: expression
@@ -561,7 +575,7 @@ class BiharmonicKernel(ExpressionKernel):
         return laplacian(laplacian(w))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class HelmholtzKernel(ExpressionKernel):
     """
     .. autoattribute:: helmholtz_k_name
@@ -642,7 +656,7 @@ class HelmholtzKernel(ExpressionKernel):
         return laplacian(w) + k**2 * w
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class YukawaKernel(ExpressionKernel):
     """
     .. autoattribute:: yukawa_lambda_name
@@ -729,7 +743,7 @@ class YukawaKernel(ExpressionKernel):
         return laplacian(w) - lam**2 * w
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class ElasticityKernel(ExpressionKernel):
     """
     .. autoattribute:: icomp
@@ -858,7 +872,7 @@ class ElasticityKernel(ExpressionKernel):
         return laplacian(laplacian(w))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class StokesletKernel(ElasticityKernel):
     """
     .. autoattribute:: icomp
@@ -898,7 +912,7 @@ class StokesletKernel(ElasticityKernel):
             f"({self.viscosity_mu}, {self.poisson_ratio})")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class StressletKernel(ExpressionKernel):
     """
     .. autoattribute:: icomp
@@ -981,7 +995,7 @@ class StressletKernel(ExpressionKernel):
         return laplacian(laplacian(w))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class LineOfCompressionKernel(ExpressionKernel):
     """A kernel for the line of compression or dilatation of constant strength
     along the axis "axis" from zero to negative infinity.


### PR DESCRIPTION
Before:
```python
LaplaceKernel(
	dim=2,
	expression=Call(Variable('log'), (Call(Variable('sqrt'), (Sum((Product((..., ...)), Product((..., ...)))),)),)),
	global_scaling_const=Quotient(1, Product((-2, Variable('pi'))))
)
```
After:
```python
LaplaceKernel(dim=2, expression=log(sqrt(d[0]*d[0] + d[1]*d[1])), global_scaling_const=1 / ((-2)*pi))
```

Thoughts? I mostly added it because the repr for the expression is quite unhelpful in the current version.