### PR TITLE
Separate ElasticityKernel and Stokeslet

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -10674,14 +10674,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 25,
                     "endColumn": 48,
                     "lineCount": 1
@@ -10848,146 +10840,10 @@
                 }
             },
             {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedParameter",
                 "range": {
                     "startColumn": 36,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnannotatedClassAttribute",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 30,
                     "lineCount": 1
                 }
             },

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -861,6 +861,11 @@ class ElasticityKernel(ExpressionKernel):
                  "raise a TypeError starting with Q1 2027.",
                  DeprecationWarning, stacklevel=2)
 
+            if poisson_ratio == 0.5:  # noqa: RUF069
+                raise ValueError(
+                    f"{type(self)} cannot accept 'poisson_ratio' of 0.5 "
+                    "(use StokesletKernel instead)")
+
             nu = poisson_ratio
 
         d = make_sym_vector("d", dim)
@@ -893,9 +898,19 @@ class ElasticityKernel(ExpressionKernel):
 
     @override
     def __reduce__(self):
+        # TODO: remove this once we stop allowing non-str values for viscosity_mu
+        viscosity_mu = (
+            self.viscosity_mu.name
+            if isinstance(self.viscosity_mu, SpatialConstant)
+            else self.viscosity_mu)
+        poisson_ratio = (
+            self.poisson_ratio.name
+            if isinstance(self.poisson_ratio, SpatialConstant)
+            else self.poisson_ratio)
+
         return (
             type(self),
-            (self.dim, self.icomp, self.jcomp, self.viscosity_mu, self.poisson_ratio))
+            (self.dim, self.icomp, self.jcomp, viscosity_mu, poisson_ratio))
 
     @property
     @override
@@ -979,6 +994,9 @@ class StokesletKernel(ExpressionKernel):
                  "argument will be removed in Q1 2027.",
                  DeprecationWarning, stacklevel=2)
 
+            if poisson_ratio != 0.5:  # noqa: RUF069
+                raise ValueError("'poisson_ratio' must be 0.5 (if provided)")
+
         if isinstance(viscosity_mu, str):
             mu = SpatialConstant(viscosity_mu)
         else:
@@ -1014,9 +1032,15 @@ class StokesletKernel(ExpressionKernel):
 
     @override
     def __reduce__(self):
+        # TODO: remove this once we stop allowing non-str values for viscosity_mu
+        viscosity_mu = (
+            self.viscosity_mu.name
+            if isinstance(self.viscosity_mu, SpatialConstant)
+            else self.viscosity_mu)
+
         return (
             type(self),
-            (self.dim, self.icomp, self.jcomp, self.viscosity_mu))
+            (self.dim, self.icomp, self.jcomp, viscosity_mu))
 
     @property
     @override
@@ -1113,10 +1137,15 @@ class StressletKernel(ExpressionKernel):
 
     @override
     def __reduce__(self) -> tuple[object, ...]:
+        # TODO: remove this once we stop allowing non-str values for viscosity_mu
+        viscosity_mu = (
+            self.viscosity_mu.name
+            if isinstance(self.viscosity_mu, SpatialConstant)
+            else self.viscosity_mu)
+
         return (
             self.__class__,
-            (self.dim, self.icomp, self.jcomp, self.kcomp, self.viscosity_mu),
-        )
+            (self.dim, self.icomp, self.jcomp, self.kcomp, viscosity_mu))
 
     @property
     @override
@@ -1200,6 +1229,9 @@ class LineOfCompressionKernel(ExpressionKernel):
                  "raise a TypeError starting with Q1 2027.",
                  DeprecationWarning, stacklevel=2)
 
+            if poisson_ratio == 0.5:  # noqa: RUF069
+                raise ValueError(f"{type(self)} cannot accept 'poisson_ratio' of 0.5")
+
             nu = poisson_ratio
 
         if dim == 3:
@@ -1226,9 +1258,19 @@ class LineOfCompressionKernel(ExpressionKernel):
 
     @override
     def __reduce__(self) -> tuple[object, ...]:
+        # TODO: remove this once we stop allowing non-str values for viscosity_mu
+        viscosity_mu = (
+            self.viscosity_mu.name
+            if isinstance(self.viscosity_mu, SpatialConstant)
+            else self.viscosity_mu)
+        poisson_ratio = (
+            self.poisson_ratio.name
+            if isinstance(self.poisson_ratio, SpatialConstant)
+            else self.poisson_ratio)
+
         return (
             self.__class__,
-            (self.dim, self.axis, self.viscosity_mu, self.poisson_ratio),
+            (self.dim, self.axis, viscosity_mu, poisson_ratio),
         )
 
     @property

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -35,7 +35,6 @@ from typing import (
     cast,
     overload,
 )
-from warnings import warn
 
 import numpy as np
 from typing_extensions import Self, override
@@ -820,9 +819,10 @@ class ElasticityKernel(ExpressionKernel):
 
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
-    .. autoattribute:: viscosity_mu
-    .. autoattribute:: poisson_ratio
+    .. autoattribute:: viscosity_mu_name
+    .. autoattribute:: poisson_ratio_name
     """
+
     mapper_method: ClassVar[str] = "map_elasticity_kernel"
 
     icomp: int
@@ -830,11 +830,11 @@ class ElasticityKernel(ExpressionKernel):
     jcomp: int
     """Component index for the kernel."""
 
-    viscosity_mu: float | SpatialConstant
+    viscosity_mu_name: str
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
     generating functions to evaluate this kernel.
     """
-    poisson_ratio: float | SpatialConstant
+    poisson_ratio_name: str
     r"""The argument name to use for Poisson's ratio :math:`\nu` when generating
     functions to evaluate this kernel.
     """
@@ -843,30 +843,20 @@ class ElasticityKernel(ExpressionKernel):
                  dim: int,
                  icomp: int,
                  jcomp: int,
-                 viscosity_mu: float | str | SpatialConstant = "mu",
-                 poisson_ratio: float | str | SpatialConstant = "nu") -> None:
-        if isinstance(viscosity_mu, str):
-            mu = SpatialConstant(viscosity_mu)
-        else:
-            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
-                 "raise a TypeError starting with Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
+                 viscosity_mu_name: str = "mu",
+                 poisson_ratio_name: str = "nu") -> None:
+        if not isinstance(viscosity_mu_name, str):
+            raise TypeError(
+                f"'viscosity_mu_name' is not a str: {type(viscosity_mu_name)}"
+            )
 
-            mu = viscosity_mu
+        if not isinstance(poisson_ratio_name, str):
+            raise TypeError(
+                f"'poisson_ratio_name' is not a str: {type(poisson_ratio_name)}"
+            )
 
-        if isinstance(poisson_ratio, str):
-            nu = SpatialConstant(poisson_ratio)
-        else:
-            warn("Passing a non-str 'poisson_ratio' is deprecated. This will "
-                 "raise a TypeError starting with Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
-
-            if poisson_ratio == 0.5:  # noqa: RUF069
-                raise ValueError(
-                    f"{type(self)} cannot accept 'poisson_ratio' of 0.5 "
-                    "(use StokesletKernel instead)")
-
-            nu = poisson_ratio
+        mu = SpatialConstant(viscosity_mu_name)
+        nu = SpatialConstant(poisson_ratio_name)
 
         d = make_sym_vector("d", dim)
         r = pymbolic_real_norm_2(d)
@@ -887,30 +877,22 @@ class ElasticityKernel(ExpressionKernel):
 
         object.__setattr__(self, "icomp", icomp)
         object.__setattr__(self, "jcomp", jcomp)
-        object.__setattr__(self, "viscosity_mu", mu)
-        object.__setattr__(self, "poisson_ratio", nu)
+        object.__setattr__(self, "viscosity_mu_name", viscosity_mu_name)
+        object.__setattr__(self, "poisson_ratio_name", poisson_ratio_name)
 
     @override
     def __str__(self) -> str:
         return (
             f"ElasticityKnl{self.dim}D_{self.icomp}{self.jcomp}"
-            f"({self.viscosity_mu}, {self.poisson_ratio})")
+            f"({self.viscosity_mu_name}, {self.poisson_ratio_name})")
 
     @override
     def __reduce__(self):
-        # TODO: remove this once we stop allowing non-str values for viscosity_mu
-        viscosity_mu = (
-            self.viscosity_mu.name
-            if isinstance(self.viscosity_mu, SpatialConstant)
-            else self.viscosity_mu)
-        poisson_ratio = (
-            self.poisson_ratio.name
-            if isinstance(self.poisson_ratio, SpatialConstant)
-            else self.poisson_ratio)
-
         return (
             type(self),
-            (self.dim, self.icomp, self.jcomp, viscosity_mu, poisson_ratio))
+            (self.dim, self.icomp, self.jcomp,
+             self.viscosity_mu_name,
+             self.poisson_ratio_name))
 
     @property
     @override
@@ -920,26 +902,10 @@ class ElasticityKernel(ExpressionKernel):
     @memoize_method
     @override
     def get_args(self) -> Sequence[KernelArgument]:
-        from sumpy.tools import get_all_variables
-        variables = get_all_variables(self.viscosity_mu)
-
-        args: list[KernelArgument] = [
-            KernelArgument(loopy_arg=lp.ValueArg(v.name, np.float64))
-            for v in variables]
-
-        return [*args, *self.get_source_args()]
-
-    @memoize_method
-    @override
-    def get_source_args(self) -> Sequence[KernelArgument]:
-        from sumpy.tools import get_all_variables
-        variables = get_all_variables(self.poisson_ratio)
-
-        args: list[KernelArgument] = [
-            KernelArgument(loopy_arg=lp.ValueArg(v.name, np.float64))
-            for v in variables]
-
-        return args
+        return [
+            KernelArgument(loopy_arg=lp.ValueArg(self.viscosity_mu_name, np.float64)),
+            KernelArgument(loopy_arg=lp.ValueArg(self.poisson_ratio_name, np.float64)),
+        ]
 
     @override
     def get_pde_as_diff_op(self) -> LinearPDESystemOperator:
@@ -968,7 +934,7 @@ class StokesletKernel(ExpressionKernel):
 
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
-    .. autoattribute:: viscosity_mu
+    .. autoattribute:: viscosity_mu_name
     """
 
     mapper_method: ClassVar[str] = "map_stokeslet_kernel"
@@ -978,7 +944,7 @@ class StokesletKernel(ExpressionKernel):
     jcomp: int
     """Component index for the kernel."""
 
-    viscosity_mu: float | SpatialConstant
+    viscosity_mu_name: str
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
     generating functions to evaluate this kernel.
     """
@@ -987,24 +953,12 @@ class StokesletKernel(ExpressionKernel):
                  dim: int,
                  icomp: int,
                  jcomp: int,
-                 viscosity_mu: float | str | SpatialConstant = "mu",
-                 poisson_ratio: float | str | SpatialConstant | None = None) -> None:
-        if poisson_ratio is not None:
-            warn(f"Passing 'poisson_ratio' to {type(self)} is deprecated. This "
-                 "argument will be removed in Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
-
-            if poisson_ratio != 0.5:  # noqa: RUF069
-                raise ValueError("'poisson_ratio' must be 0.5 (if provided)")
-
-        if isinstance(viscosity_mu, str):
-            mu = SpatialConstant(viscosity_mu)
-        else:
-            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
-                 "raise a TypeError starting with Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
-
-            mu = viscosity_mu
+                 viscosity_mu_name: str = "mu") -> None:
+        if not isinstance(viscosity_mu_name, str):
+            raise TypeError(
+                f"'viscosity_mu_name' is not a str: {type(viscosity_mu_name)}"
+            )
+        mu = SpatialConstant(viscosity_mu_name)
 
         d = make_sym_vector("d", dim)
         r = pymbolic_real_norm_2(d)
@@ -1022,25 +976,19 @@ class StokesletKernel(ExpressionKernel):
         super().__init__(dim, expression=expr, global_scaling_const=scaling)
         object.__setattr__(self, "icomp", icomp)
         object.__setattr__(self, "jcomp", jcomp)
-        object.__setattr__(self, "viscosity_mu", mu)
+        object.__setattr__(self, "viscosity_mu_name", viscosity_mu_name)
 
     @override
     def __str__(self) -> str:
         return (
             f"StokesletKnl{self.dim}D_{self.icomp}{self.jcomp}"
-            f"({self.viscosity_mu})")
+            f"({self.viscosity_mu_name})")
 
     @override
     def __reduce__(self):
-        # TODO: remove this once we stop allowing non-str values for viscosity_mu
-        viscosity_mu = (
-            self.viscosity_mu.name
-            if isinstance(self.viscosity_mu, SpatialConstant)
-            else self.viscosity_mu)
-
         return (
             type(self),
-            (self.dim, self.icomp, self.jcomp, viscosity_mu))
+            (self.dim, self.icomp, self.jcomp, self.viscosity_mu_name))
 
     @property
     @override
@@ -1050,15 +998,11 @@ class StokesletKernel(ExpressionKernel):
     @memoize_method
     @override
     def get_args(self) -> Sequence[KernelArgument]:
-        # TODO: remove this once we stop allowing non-str values for viscosity_mu
-        if isinstance(self.viscosity_mu, SpatialConstant):
-            return [
-                KernelArgument(
-                    loopy_arg=lp.ValueArg(self.viscosity_mu.name, np.float64),
-                )
-            ]
-        else:
-            return []
+        return [
+            KernelArgument(
+                loopy_arg=lp.ValueArg(self.viscosity_mu_name, np.float64),
+            )
+        ]
 
     @override
     def get_pde_as_diff_op(self) -> LinearPDESystemOperator:
@@ -1084,7 +1028,7 @@ class StressletKernel(ExpressionKernel):
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
     .. autoattribute:: kcomp
-    .. autoattribute:: viscosity_mu
+    .. autoattribute:: viscosity_mu_name
     """
     mapper_method: ClassVar[str] = "map_stresslet_kernel"
 
@@ -1095,7 +1039,7 @@ class StressletKernel(ExpressionKernel):
     kcomp: int
     """Component index for the kernel."""
 
-    viscosity_mu: float | SpatialConstant
+    viscosity_mu_name: str
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
     generating functions to evaluate this kernel.
     """
@@ -1105,16 +1049,12 @@ class StressletKernel(ExpressionKernel):
                  icomp: int,
                  jcomp: int,
                  kcomp: int,
-                 viscosity_mu: float | str | SpatialConstant = "mu") -> None:
+                 viscosity_mu_name: str = "mu") -> None:
         # mu is unused but kept for consistency with the Stokeslet.
-        if isinstance(viscosity_mu, str):
-            mu = SpatialConstant(viscosity_mu)
-        else:
-            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
-                 "raise a TypeError starting with Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
-
-            mu = viscosity_mu
+        if not isinstance(viscosity_mu_name, str):
+            raise TypeError(
+                f"'viscosity_mu_name' is not a str: {type(viscosity_mu_name)}"
+            )
 
         d = make_sym_vector("d", dim)
         r = pymbolic_real_norm_2(d)
@@ -1133,39 +1073,33 @@ class StressletKernel(ExpressionKernel):
         object.__setattr__(self, "icomp", icomp)
         object.__setattr__(self, "jcomp", jcomp)
         object.__setattr__(self, "kcomp", kcomp)
-        object.__setattr__(self, "viscosity_mu", mu)
+        object.__setattr__(self, "viscosity_mu_name", viscosity_mu_name)
 
     @override
     def __reduce__(self) -> tuple[object, ...]:
-        # TODO: remove this once we stop allowing non-str values for viscosity_mu
-        viscosity_mu = (
-            self.viscosity_mu.name
-            if isinstance(self.viscosity_mu, SpatialConstant)
-            else self.viscosity_mu)
-
         return (
             self.__class__,
-            (self.dim, self.icomp, self.jcomp, self.kcomp, viscosity_mu))
+            (self.dim, self.icomp, self.jcomp, self.kcomp,
+             self.viscosity_mu_name))
 
     @property
     @override
     def is_complex_valued(self) -> bool:
         return False
 
+    @memoize_method
+    @override
+    def get_args(self) -> Sequence[KernelArgument]:
+        # NOTE: this is not used, but kept for symmetry with the StokesletKernel
+        return [
+            KernelArgument(loopy_arg=lp.ValueArg(self.viscosity_mu_name, np.float64))
+        ]
+
     @override
     def __str__(self) -> str:
         return (
             f"StressletKnl{self.dim}D_{self.icomp}{self.jcomp}{self.kcomp}"
-            f"({self.viscosity_mu})")
-
-    @memoize_method
-    @override
-    def get_args(self) -> Sequence[KernelArgument]:
-        from sumpy.tools import get_all_variables
-        variables = get_all_variables(self.viscosity_mu)
-        return [
-                KernelArgument(loopy_arg=lp.ValueArg(v.name, np.float64))
-                for v in variables]
+            f"({self.viscosity_mu_name})")
 
     @override
     def get_pde_as_diff_op(self) -> LinearPDESystemOperator:
@@ -1189,8 +1123,8 @@ class LineOfCompressionKernel(ExpressionKernel):
          `doi:10.1063/1.1745385 <https://doi.org/10.1063/1.1745385>`__.
 
     .. autoattribute:: axis
-    .. autoattribute:: viscosity_mu
-    .. autoattribute:: poisson_ratio
+    .. autoattribute:: viscosity_mu_name
+    .. autoattribute:: poisson_ratio_name
     """
 
     mapper_method: ClassVar[str] = "map_line_of_compression_kernel"
@@ -1198,11 +1132,11 @@ class LineOfCompressionKernel(ExpressionKernel):
     axis: int
     """Axis number (defaulting to 2 for the z axis)."""
 
-    viscosity_mu: float | SpatialConstant
+    viscosity_mu_name: str
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
     generating functions to evaluate this kernel.
     """
-    poisson_ratio: float | SpatialConstant
+    poisson_ratio_name: str
     r"""The argument name to use for Poisson's ratio :math:`\nu` when
     generating functions to evaluate this kernel.
     """
@@ -1210,29 +1144,21 @@ class LineOfCompressionKernel(ExpressionKernel):
     def __init__(self,
                  dim: int = 3,
                  axis: int = 2,
-                 viscosity_mu: float | str | SpatialConstant = "mu",
-                 poisson_ratio: float | str | SpatialConstant = "nu"
+                 viscosity_mu_name: str = "mu",
+                 poisson_ratio_name: str = "nu"
              ) -> None:
-        if isinstance(viscosity_mu, str):
-            mu = SpatialConstant(viscosity_mu)
-        else:
-            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
-                 "raise a TypeError starting with Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
+        if not isinstance(viscosity_mu_name, str):
+            raise TypeError(
+                f"'viscosity_mu_name' is not a str: {type(viscosity_mu_name)}"
+            )
 
-            mu = viscosity_mu
+        if not isinstance(poisson_ratio_name, str):
+            raise TypeError(
+                f"'poisson_ratio_name' is not a str: {type(poisson_ratio_name)}"
+            )
 
-        if isinstance(poisson_ratio, str):
-            nu = SpatialConstant(poisson_ratio)
-        else:
-            warn("Passing a non-str 'poisson_ratio' is deprecated. This will "
-                 "raise a TypeError starting with Q1 2027.",
-                 DeprecationWarning, stacklevel=2)
-
-            if poisson_ratio == 0.5:  # noqa: RUF069
-                raise ValueError(f"{type(self)} cannot accept 'poisson_ratio' of 0.5")
-
-            nu = poisson_ratio
+        mu = SpatialConstant(viscosity_mu_name)
+        nu = SpatialConstant(poisson_ratio_name)
 
         if dim == 3:
             d = make_sym_vector("d", dim)
@@ -1247,31 +1173,21 @@ class LineOfCompressionKernel(ExpressionKernel):
         super().__init__(dim, expression=expr, global_scaling_const=scaling)
 
         object.__setattr__(self, "axis", axis)
-        object.__setattr__(self, "viscosity_mu", mu)
-        object.__setattr__(self, "poisson_ratio", nu)
+        object.__setattr__(self, "viscosity_mu_name", viscosity_mu_name)
+        object.__setattr__(self, "poisson_ratio_name", poisson_ratio_name)
 
     @override
     def __str__(self) -> str:
         return (
             f"LineOfCompressionKnl{self.dim}D_{self.axis}"
-            f"({self.viscosity_mu}, {self.poisson_ratio})")
+            f"({self.viscosity_mu_name}, {self.poisson_ratio_name})")
 
     @override
     def __reduce__(self) -> tuple[object, ...]:
-        # TODO: remove this once we stop allowing non-str values for viscosity_mu
-        viscosity_mu = (
-            self.viscosity_mu.name
-            if isinstance(self.viscosity_mu, SpatialConstant)
-            else self.viscosity_mu)
-        poisson_ratio = (
-            self.poisson_ratio.name
-            if isinstance(self.poisson_ratio, SpatialConstant)
-            else self.poisson_ratio)
-
         return (
             self.__class__,
-            (self.dim, self.axis, viscosity_mu, poisson_ratio),
-        )
+            (self.dim, self.axis,
+             self.viscosity_mu_name, self.poisson_ratio_name))
 
     @property
     @override
@@ -1281,16 +1197,10 @@ class LineOfCompressionKernel(ExpressionKernel):
     @memoize_method
     @override
     def get_args(self) -> Sequence[KernelArgument]:
-        from sumpy.tools import get_all_variables
-        variables = [
-            *get_all_variables(self.viscosity_mu),
-            *get_all_variables(self.poisson_ratio)]
-
-        args: list[KernelArgument] = [
-            KernelArgument(loopy_arg=lp.ValueArg(v.name, np.float64))
-            for v in variables]
-
-        return args
+        return [
+            KernelArgument(loopy_arg=lp.ValueArg(self.viscosity_mu_name, np.float64)),
+            KernelArgument(loopy_arg=lp.ValueArg(self.poisson_ratio_name, np.float64)),
+        ]
 
     @override
     def get_pde_as_diff_op(self) -> LinearPDESystemOperator:

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -38,7 +38,7 @@ from typing import (
 from warnings import warn
 
 import numpy as np
-from typing_extensions import override
+from typing_extensions import Self, override
 
 import loopy as lp
 import pymbolic.primitives as prim
@@ -2023,16 +2023,26 @@ class KernelIdentityMapper(KernelMapper[Kernel]):
     def map_expression_kernel(self, kernel: ExpressionKernel) -> Kernel:
         return kernel
 
-    map_laplace_kernel = map_expression_kernel
-    map_biharmonic_kernel = map_expression_kernel
-    map_helmholtz_kernel = map_expression_kernel
-    map_yukawa_kernel = map_expression_kernel
-    map_elasticity_kernel = map_expression_kernel
-    map_line_of_compression_kernel = map_expression_kernel
-    map_stokeslet_kernel = map_expression_kernel
-    map_stresslet_kernel = map_expression_kernel
-    map_brinkmanlet_kernel = map_expression_kernel
-    map_brinkman_stress_kernel = map_expression_kernel
+    map_laplace_kernel: \
+        Callable[[Self, LaplaceKernel], Kernel] = map_expression_kernel
+    map_biharmonic_kernel: \
+        Callable[[Self, BiharmonicKernel], Kernel] = map_expression_kernel
+    map_helmholtz_kernel: \
+        Callable[[Self, HelmholtzKernel], Kernel] = map_expression_kernel
+    map_yukawa_kernel: \
+        Callable[[Self, YukawaKernel], Kernel] = map_expression_kernel
+    map_elasticity_kernel: \
+        Callable[[Self, ElasticityKernel], Kernel] = map_expression_kernel
+    map_line_of_compression_kernel: \
+        Callable[[Self, LineOfCompressionKernel], Kernel] = map_expression_kernel
+    map_stokeslet_kernel: \
+        Callable[[Self, StokesletKernel], Kernel] = map_expression_kernel
+    map_stresslet_kernel: \
+        Callable[[Self, StressletKernel], Kernel] = map_expression_kernel
+    map_brinkmanlet_kernel: \
+        Callable[[Self, BrinkmanletKernel], Kernel] = map_expression_kernel
+    map_brinkman_stress_kernel: \
+        Callable[[Self, BrinkmanStressKernel], Kernel] = map_expression_kernel
 
     def map_axis_target_derivative(self, kernel: AxisTargetDerivative) -> Kernel:
         return type(kernel)(kernel.axis, self.rec(kernel.inner_kernel))
@@ -2099,16 +2109,26 @@ class DerivativeCounter(KernelCombineMapper[int]):
     def map_expression_kernel(self, kernel: ExpressionKernel) -> int:
         return 0
 
-    map_laplace_kernel = map_expression_kernel
-    map_biharmonic_kernel = map_expression_kernel
-    map_helmholtz_kernel = map_expression_kernel
-    map_yukawa_kernel = map_expression_kernel
-    map_elasticity_kernel = map_expression_kernel
-    map_line_of_compression_kernel = map_expression_kernel
-    map_stokeslet_kernel = map_expression_kernel
-    map_stresslet_kernel = map_expression_kernel
-    map_brinkmanlet_kernel = map_expression_kernel
-    map_brinkman_stress_kernel = map_expression_kernel
+    map_laplace_kernel: \
+        Callable[[Self, LaplaceKernel], int] = map_expression_kernel
+    map_biharmonic_kernel: \
+        Callable[[Self, BiharmonicKernel], int] = map_expression_kernel
+    map_helmholtz_kernel: \
+        Callable[[Self, HelmholtzKernel], int] = map_expression_kernel
+    map_yukawa_kernel: \
+        Callable[[Self, YukawaKernel], int] = map_expression_kernel
+    map_elasticity_kernel: \
+        Callable[[Self, ElasticityKernel], int] = map_expression_kernel
+    map_line_of_compression_kernel: \
+        Callable[[Self, LineOfCompressionKernel], int] = map_expression_kernel
+    map_stokeslet_kernel: \
+        Callable[[Self, StokesletKernel], int] = map_expression_kernel
+    map_stresslet_kernel: \
+        Callable[[Self, StressletKernel], int] = map_expression_kernel
+    map_brinkmanlet_kernel: \
+        Callable[[Self, BrinkmanletKernel], int] = map_expression_kernel
+    map_brinkman_stress_kernel: \
+        Callable[[Self, BrinkmanStressKernel], int] = map_expression_kernel
 
     @override
     def map_axis_target_derivative(self, kernel: AxisTargetDerivative) -> int:

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -35,9 +35,10 @@ from typing import (
     cast,
     overload,
 )
+from warnings import warn
 
 import numpy as np
-from typing_extensions import Self, override
+from typing_extensions import override
 
 import loopy as lp
 import pymbolic.primitives as prim
@@ -785,59 +786,49 @@ class ElasticityKernel(ExpressionKernel):
 
     viscosity_mu: float | SpatialConstant
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
-    generating functions to evaluate this kernel. Can also be a numeric value.
+    generating functions to evaluate this kernel.
     """
     poisson_ratio: float | SpatialConstant
     r"""The argument name to use for Poisson's ratio :math:`\nu` when generating
-    functions to evaluate this kernel. Can also be a numeric value.
+    functions to evaluate this kernel.
     """
 
-    def __new__(cls,
-                dim: int, icomp: int, jcomp: int,
-                viscosity_mu: float | str | SpatialConstant = "mu",
-                poisson_ratio: float | str | SpatialConstant = "nu",
-        ) -> Self:
-        if poisson_ratio == 0.5:  # noqa: RUF069
-            return super().__new__(StokesletKernel)
-        else:
-            return super().__new__(cls)
-
     def __init__(self,
-                 dim: int, icomp: int, jcomp: int,
+                 dim: int,
+                 icomp: int,
+                 jcomp: int,
                  viscosity_mu: float | str | SpatialConstant = "mu",
                  poisson_ratio: float | str | SpatialConstant = "nu") -> None:
         if isinstance(viscosity_mu, str):
             mu = SpatialConstant(viscosity_mu)
         else:
+            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
+                 "raise a TypeError starting with Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
+
             mu = viscosity_mu
 
         if isinstance(poisson_ratio, str):
             nu = SpatialConstant(poisson_ratio)
         else:
+            warn("Passing a non-str 'poisson_ratio' is deprecated. This will "
+                 "raise a TypeError starting with Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
+
             nu = poisson_ratio
 
+        d = make_sym_vector("d", dim)
+        r = pymbolic_real_norm_2(d)
+        delta_ij = 1 if icomp == jcomp else 0
+
         if dim == 2:
-            d = make_sym_vector("d", dim)
-            r = pymbolic_real_norm_2(d)
             # See (Berger and Karageorghis 2001)
-            expr = (
-                -var("log")(r)*((3 - 4 * nu) if icomp == jcomp else 0)
-                +
-                d[icomp]*d[jcomp]/r**2
-                )
+            expr = -var("log")(r)*(3 - 4 * nu)*delta_ij + d[icomp]*d[jcomp]/r**2
             scaling = -1/(8*var("pi")*(1 - nu)*mu)
-
         elif dim == 3:
-            d = make_sym_vector("d", dim)
-            r = pymbolic_real_norm_2(d)
             # Kelvin solution
-            expr = (
-                (1/r)*((3 - 4*nu) if icomp == jcomp else 0)
-                +
-                d[icomp]*d[jcomp]/r**3
-                )
+            expr = (1/r)*(3 - 4*nu)*delta_ij + d[icomp]*d[jcomp]/r**3
             scaling = -1/(16*var("pi")*(1 - nu)*mu)
-
         else:
             raise NotImplementedError(f"unsupported dimension: '{dim}'")
 
@@ -849,6 +840,12 @@ class ElasticityKernel(ExpressionKernel):
         object.__setattr__(self, "poisson_ratio", nu)
 
     @override
+    def __str__(self) -> str:
+        return (
+            f"ElasticityKnl{self.dim}D_{self.icomp}{self.jcomp}"
+            f"({self.viscosity_mu}, {self.poisson_ratio})")
+
+    @override
     def __reduce__(self):
         return (
             type(self),
@@ -858,12 +855,6 @@ class ElasticityKernel(ExpressionKernel):
     @override
     def is_complex_valued(self) -> bool:
         return False
-
-    @override
-    def __str__(self) -> str:
-        return (
-            f"ElasticityKnl{self.dim}D_{self.icomp}{self.jcomp}"
-            f"({self.viscosity_mu}, {self.poisson_ratio})")
 
     @memoize_method
     @override
@@ -898,43 +889,99 @@ class ElasticityKernel(ExpressionKernel):
 
 
 @dataclass(frozen=True, repr=False)
-class StokesletKernel(ElasticityKernel):
+class StokesletKernel(ExpressionKernel):
     """
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
     .. autoattribute:: viscosity_mu
     """
 
-    def __new__(cls,
-                dim: int,
-                icomp: int,
-                jcomp: int,
-                viscosity_mu: float | str | SpatialConstant = "mu",
-                poisson_ratio: float | str | SpatialConstant | None = None,
-            ) -> Self:
-        return object.__new__(cls)
+    mapper_method: ClassVar[str] = "map_stokeslet_kernel"
+
+    icomp: int
+    """Component index for the kernel."""
+    jcomp: int
+    """Component index for the kernel."""
+
+    viscosity_mu: float | SpatialConstant
+    r"""The argument name to use for the dynamic viscosity :math:`\mu` when
+    generating functions to evaluate this kernel.
+    """
 
     def __init__(self,
-                dim: int,
-                icomp: int,
-                jcomp: int,
-                viscosity_mu: float | str | SpatialConstant = "mu",
-                poisson_ratio: float | str | SpatialConstant | None = None) -> None:
-        if poisson_ratio is None:
-            poisson_ratio = 0.5
+                 dim: int,
+                 icomp: int,
+                 jcomp: int,
+                 viscosity_mu: float | str | SpatialConstant = "mu",
+                 poisson_ratio: float | str | SpatialConstant | None = None) -> None:
+        if poisson_ratio is not None:
+            warn(f"Passing 'poisson_ratio' to {type(self)} is deprecated. This "
+                 "argument will be removed in Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
 
-        if poisson_ratio != 0.5:  # noqa: RUF069
-            raise ValueError(
-                "'StokesletKernel' must have a Poisson ratio of 0.5: "
-                f"got '{poisson_ratio}'")
+        if isinstance(viscosity_mu, str):
+            mu = SpatialConstant(viscosity_mu)
+        else:
+            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
+                 "raise a TypeError starting with Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
 
-        super().__init__(dim, icomp, jcomp, viscosity_mu, poisson_ratio)
+            mu = viscosity_mu
+
+        d = make_sym_vector("d", dim)
+        r = pymbolic_real_norm_2(d)
+        delta_ij = 1 if icomp == jcomp else 0
+
+        if dim == 2:
+            expr = -var("log")(r)*delta_ij + d[icomp]*d[jcomp]/r**2
+            scaling = -1/(4*var("pi")*mu)
+        elif dim == 3:
+            expr = (1/r)*delta_ij + d[icomp]*d[jcomp]/r**3
+            scaling = -1/(8*var("pi")*mu)
+        else:
+            raise NotImplementedError(f"unsupported dimension: '{dim}'")
+
+        super().__init__(dim, expression=expr, global_scaling_const=scaling)
+        object.__setattr__(self, "icomp", icomp)
+        object.__setattr__(self, "jcomp", jcomp)
+        object.__setattr__(self, "viscosity_mu", mu)
 
     @override
     def __str__(self) -> str:
         return (
             f"StokesletKnl{self.dim}D_{self.icomp}{self.jcomp}"
-            f"({self.viscosity_mu}, {self.poisson_ratio})")
+            f"({self.viscosity_mu})")
+
+    @override
+    def __reduce__(self):
+        return (
+            type(self),
+            (self.dim, self.icomp, self.jcomp, self.viscosity_mu))
+
+    @property
+    @override
+    def is_complex_valued(self) -> bool:
+        return False
+
+    @memoize_method
+    @override
+    def get_args(self) -> Sequence[KernelArgument]:
+        # TODO: remove this once we stop allowing non-str values for viscosity_mu
+        if isinstance(self.viscosity_mu, SpatialConstant):
+            return [
+                KernelArgument(
+                    loopy_arg=lp.ValueArg(self.viscosity_mu.name, np.float64),
+                )
+            ]
+        else:
+            return []
+
+    @override
+    def get_pde_as_diff_op(self) -> LinearPDESystemOperator:
+        from sumpy.expansion.diff_op import laplacian, make_identity_diff_op
+
+        w = make_identity_diff_op(self.dim)
+        return laplacian(laplacian(w))
 
 
 @dataclass(frozen=True, repr=False)
@@ -953,36 +1000,37 @@ class StressletKernel(ExpressionKernel):
     """Component index for the kernel."""
     kcomp: int
     """Component index for the kernel."""
+
     viscosity_mu: float | SpatialConstant
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
-    generating functions to evaluate this kernel. Can also be a numeric value.
+    generating functions to evaluate this kernel.
     """
 
     def __init__(self,
-                 dim: int, icomp: int, jcomp: int, kcomp: int,
+                 dim: int,
+                 icomp: int,
+                 jcomp: int,
+                 kcomp: int,
                  viscosity_mu: float | str | SpatialConstant = "mu") -> None:
         # mu is unused but kept for consistency with the Stokeslet.
         if isinstance(viscosity_mu, str):
             mu = SpatialConstant(viscosity_mu)
         else:
+            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
+                 "raise a TypeError starting with Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
+
             mu = viscosity_mu
 
+        d = make_sym_vector("d", dim)
+        r = pymbolic_real_norm_2(d)
+
         if dim == 2:
-            d = make_sym_vector("d", dim)
-            r = pymbolic_real_norm_2(d)
-            expr = (
-                d[icomp]*d[jcomp]*d[kcomp]/r**4
-                )
+            expr = d[icomp]*d[jcomp]*d[kcomp]/r**4
             scaling = 1/(var("pi"))
-
         elif dim == 3:
-            d = make_sym_vector("d", dim)
-            r = pymbolic_real_norm_2(d)
-            expr = (
-                d[icomp]*d[jcomp]*d[kcomp]/r**5
-                )
+            expr = d[icomp]*d[jcomp]*d[kcomp]/r**5
             scaling = 3/(4*var("pi"))
-
         else:
             raise NotImplementedError(f"unsupported dimension: '{dim}'")
 
@@ -1023,6 +1071,7 @@ class StressletKernel(ExpressionKernel):
     @override
     def get_pde_as_diff_op(self) -> LinearPDESystemOperator:
         from sumpy.expansion.diff_op import laplacian, make_identity_diff_op
+
         w = make_identity_diff_op(self.dim)
         return laplacian(laplacian(w))
 

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -2029,6 +2029,7 @@ class KernelIdentityMapper(KernelMapper[Kernel]):
     map_yukawa_kernel = map_expression_kernel
     map_elasticity_kernel = map_expression_kernel
     map_line_of_compression_kernel = map_expression_kernel
+    map_stokeslet_kernel = map_expression_kernel
     map_stresslet_kernel = map_expression_kernel
     map_brinkmanlet_kernel = map_expression_kernel
     map_brinkman_stress_kernel = map_expression_kernel
@@ -2102,7 +2103,9 @@ class DerivativeCounter(KernelCombineMapper[int]):
     map_biharmonic_kernel = map_expression_kernel
     map_helmholtz_kernel = map_expression_kernel
     map_yukawa_kernel = map_expression_kernel
+    map_elasticity_kernel = map_expression_kernel
     map_line_of_compression_kernel = map_expression_kernel
+    map_stokeslet_kernel = map_expression_kernel
     map_stresslet_kernel = map_expression_kernel
     map_brinkmanlet_kernel = map_expression_kernel
     map_brinkman_stress_kernel = map_expression_kernel

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -1098,13 +1098,14 @@ class LineOfCompressionKernel(ExpressionKernel):
 
     axis: int
     """Axis number (defaulting to 2 for the z axis)."""
+
     viscosity_mu: float | SpatialConstant
     r"""The argument name to use for the dynamic viscosity :math:`\mu` when
-    generating functions to evaluate this kernel. Can also be a numeric value.
+    generating functions to evaluate this kernel.
     """
     poisson_ratio: float | SpatialConstant
     r"""The argument name to use for Poisson's ratio :math:`\nu` when
-    generating functions to evaluate this kernel. Can also be a numeric value.
+    generating functions to evaluate this kernel.
     """
 
     def __init__(self,
@@ -1116,15 +1117,25 @@ class LineOfCompressionKernel(ExpressionKernel):
         if isinstance(viscosity_mu, str):
             mu = SpatialConstant(viscosity_mu)
         else:
+            warn("Passing a non-str 'viscosity_mu' is deprecated. This will "
+                 "raise a TypeError starting with Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
+
             mu = viscosity_mu
+
         if isinstance(poisson_ratio, str):
             nu = SpatialConstant(poisson_ratio)
         else:
+            warn("Passing a non-str 'poisson_ratio' is deprecated. This will "
+                 "raise a TypeError starting with Q1 2027.",
+                 DeprecationWarning, stacklevel=2)
+
             nu = poisson_ratio
 
         if dim == 3:
             d = make_sym_vector("d", dim)
             r = pymbolic_real_norm_2(d)
+
             # Kelvin solution
             expr = d[axis] * var("log")(r + d[axis]) - r
             scaling = (1 - 2*nu)/(4*var("pi")*mu)
@@ -1138,6 +1149,12 @@ class LineOfCompressionKernel(ExpressionKernel):
         object.__setattr__(self, "poisson_ratio", nu)
 
     @override
+    def __str__(self) -> str:
+        return (
+            f"LineOfCompressionKnl{self.dim}D_{self.axis}"
+            f"({self.viscosity_mu}, {self.poisson_ratio})")
+
+    @override
     def __reduce__(self) -> tuple[object, ...]:
         return (
             self.__class__,
@@ -1148,10 +1165,6 @@ class LineOfCompressionKernel(ExpressionKernel):
     @override
     def is_complex_valued(self) -> bool:
         return False
-
-    @override
-    def __str__(self) -> str:
-        return f"LineOfCompressionKnl{self.dim}D_{self.axis}"
 
     @memoize_method
     @override
@@ -1170,6 +1183,7 @@ class LineOfCompressionKernel(ExpressionKernel):
     @override
     def get_pde_as_diff_op(self) -> LinearPDESystemOperator:
         from sumpy.expansion.diff_op import laplacian, make_identity_diff_op
+
         w = make_identity_diff_op(self.dim)
         return laplacian(w)
 

--- a/sumpy/kernel.py
+++ b/sumpy/kernel.py
@@ -114,6 +114,18 @@ PDE kernels
     :show-inheritance:
     :members: mapper_method
 
+.. [Pozrikidis1992] C. Pozrikidis,
+    *Boundary Integral and Singularity Methods for Linearized Viscous Flow*,
+    Cambridge University Press, 1992.
+
+.. [Hsiao2008] G. C. Hsiao, W. L. Wendland,
+    *Boundary Integral Equations*,
+    Springer, 2008.
+
+.. [Kress2013] R. Kress,
+    *Linear Integral Equations*,
+    Springer Science & Business Media, 2013.
+
 Derivatives
 -----------
 
@@ -490,6 +502,13 @@ one_kernel_3d = OneKernel(3)
 # {{{ PDE kernels
 
 class LaplaceKernel(ExpressionKernel):
+    r"""A kernel for the Laplace equation (see e.g. Theorem 6.2 from [Kress2013]_).
+
+    .. math::
+
+        \Delta K(\mathbf{x}, \mathbf{y}) = \delta(\mathbf{x} - \mathbf{y}).
+    """
+
     mapper_method: ClassVar[str] = "map_laplace_kernel"
 
     def __init__(self, dim: int) -> None:
@@ -538,6 +557,13 @@ class LaplaceKernel(ExpressionKernel):
 
 
 class BiharmonicKernel(ExpressionKernel):
+    r"""A kernel for the biharmonic equation.
+
+    .. math::
+
+        \Delta^2 K(\mathbf{x}, \mathbf{y}) = \delta(\mathbf{x} - \mathbf{y}).
+    """
+
     mapper_method: ClassVar[str] = "map_biharmonic_kernel"
 
     def __init__(self, dim: int) -> None:
@@ -592,7 +618,13 @@ class BiharmonicKernel(ExpressionKernel):
 
 @dataclass(frozen=True, repr=False)
 class HelmholtzKernel(ExpressionKernel):
-    """
+    r"""A kernel for the Helmholtz equation (see e.g. Example 12.14 in [Kress2013]_).
+
+    .. math::
+
+        \Delta K(\mathbf{x}, \mathbf{y}) + k^2 K(\mathbf{x}, \mathbf{y})
+            = \delta(\mathbf{x} - \mathbf{y}).
+
     .. autoattribute:: helmholtz_k_name
     .. autoattribute:: allow_evanescent
     """
@@ -680,7 +712,13 @@ class HelmholtzKernel(ExpressionKernel):
 
 @dataclass(frozen=True, repr=False)
 class YukawaKernel(ExpressionKernel):
-    """
+    r"""A kernel for the Yukawa equation.
+
+    .. math::
+
+        \Delta K(\mathbf{x}, \mathbf{y}) - \lambda^2 K(\mathbf{x}, \mathbf{y})
+            = \delta(\mathbf{x} - \mathbf{y}).
+
     .. autoattribute:: yukawa_lambda_name
     """
 
@@ -771,7 +809,15 @@ class YukawaKernel(ExpressionKernel):
 
 @dataclass(frozen=True, repr=False)
 class ElasticityKernel(ExpressionKernel):
-    """
+    r"""A kernel for the linear elasticity (Navier-Cauchy) equations
+    (see e.g. Section 2.2 in [Hsiao2008]_).
+
+    .. math::
+
+        \mu \Delta K_{ij}(\mathbf{x}, \mathbf{y})
+        + \frac{\mu}{1 - 2 \nu} \nabla (\nabla \cdot K_{ij}(\mathbf{x}, \mathbf{y}))
+        = \delta_{ij} \delta(\mathbf{x} - \mathbf{y}).
+
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
     .. autoattribute:: viscosity_mu
@@ -890,7 +936,21 @@ class ElasticityKernel(ExpressionKernel):
 
 @dataclass(frozen=True, repr=False)
 class StokesletKernel(ExpressionKernel):
-    """
+    r"""A kernel for the Stokes equations (see e.g. Chapter 2 in [Pozrikidis1992]_).
+
+    .. math::
+
+        \begin{cases}
+        -\mu \Delta K_{ij}(\mathbf{x}, \mathbf{y})
+            + \nabla_i P_j(\mathbf{x}, \mathbf{y})
+            = \delta_{ij} \delta(\mathbf{x} - \mathbf{y}), \\
+        \nabla_i K_{ij}(\mathbf{x}, \mathbf{y}) = 0, \\
+        \end{cases}
+
+    where pressure kernel :math:`P_j = \partial_j K` is the derivative of the
+    Laplace kernel. This kernel is often called the Stokeslet or the Oseen-Burgers
+    tensor and it represents the velocity field.
+
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
     .. autoattribute:: viscosity_mu
@@ -986,7 +1046,17 @@ class StokesletKernel(ExpressionKernel):
 
 @dataclass(frozen=True, repr=False)
 class StressletKernel(ExpressionKernel):
-    """
+    r"""A kernel for the Stokes equations (see e.g. Chapter 2 in [Pozrikidis1992]_).
+
+    .. math::
+
+        K_{ijk}(\mathbf{x}, \mathbf{y}) =
+            -P_j \delta_{ik}
+            + \mu (\partial_k K_{ij} + \partial_i K_{kj})
+
+    where the two-index :math:`K_{ij}` is the :class:`~sumpy.kernel.StokesletKernel`.
+    This kernel is often called the Stresslet and it represents the stress tensor.
+
     .. autoattribute:: icomp
     .. autoattribute:: jcomp
     .. autoattribute:: kcomp
@@ -1079,9 +1149,9 @@ class StressletKernel(ExpressionKernel):
 @dataclass(frozen=True, repr=False)
 class LineOfCompressionKernel(ExpressionKernel):
     """A kernel for the line of compression or dilatation of constant strength
-    along the axis "axis" from zero to negative infinity.
+    along an axis from zero to negative infinity.
 
-    This is used for the explicit solution to half-space Elasticity problem.
+    This is used for the explicit solution to half-space linear elasticity problem.
     See [Mindlin1936]_ for details.
 
     .. [Mindlin1936] R. D. Mindlin (1936).

--- a/sumpy/test/test_misc.py
+++ b/sumpy/test/test_misc.py
@@ -545,22 +545,20 @@ def test_as_scalar_pde_brinkman():
 # }}}
 
 
-# {{{ test_elasticity_new
+# {{{ test_elasticity_pickle
 
-def test_elasticity_new():
+def test_elasticity_pickle():
     from pickle import dumps, loads
-    stokes_knl = StokesletKernel(3, 0, 1, "mu1", 0.5)
-    stokes_knl2 = ElasticityKernel(3, 0, 1, "mu1", 0.5)
-    elasticity_knl = ElasticityKernel(3, 0, 1, "mu1", "nu")
-    elasticity_helper_knl = LineOfCompressionKernel(3, 0, "mu1", "nu")
+    stokes_knl = StokesletKernel(
+        3, 0, 1, viscosity_mu="mu1")
+    elasticity_knl = ElasticityKernel(
+        3, 0, 1, viscosity_mu="mu1", poisson_ratio="nu1")
+    elasticity_helper_knl = LineOfCompressionKernel(
+        3, 0, viscosity_mu="mu1", poisson_ratio="nu1")
 
-    assert isinstance(stokes_knl2, StokesletKernel)
-    assert stokes_knl == stokes_knl2
     assert loads(dumps(stokes_knl)) == stokes_knl
-
-    for knl in [elasticity_knl, elasticity_helper_knl]:
-        assert not isinstance(knl, StokesletKernel)
-        assert loads(dumps(knl)) == knl
+    assert loads(dumps(elasticity_knl)) == elasticity_knl
+    assert loads(dumps(elasticity_helper_knl)) == elasticity_helper_knl
 
 # }}}
 

--- a/sumpy/test/test_misc.py
+++ b/sumpy/test/test_misc.py
@@ -550,11 +550,11 @@ def test_as_scalar_pde_brinkman():
 def test_elasticity_pickle():
     from pickle import dumps, loads
     stokes_knl = StokesletKernel(
-        3, 0, 1, viscosity_mu="mu1")
+        3, 0, 1, viscosity_mu_name="mu1")
     elasticity_knl = ElasticityKernel(
-        3, 0, 1, viscosity_mu="mu1", poisson_ratio="nu1")
+        3, 0, 1, viscosity_mu_name="mu1", poisson_ratio_name="nu1")
     elasticity_helper_knl = LineOfCompressionKernel(
-        3, 0, viscosity_mu="mu1", poisson_ratio="nu1")
+        3, 0, viscosity_mu_name="mu1", poisson_ratio_name="nu1")
 
     assert loads(dumps(stokes_knl)) == stokes_knl
     assert loads(dumps(elasticity_knl)) == elasticity_knl


### PR DESCRIPTION
This makes the `StokesletKernel` an `ExpressionKernel` instead of inheriting from `ElasticityKernel`. Besides that, it also
1. Removes the `__new__` implementations. This is breaking (since `ElasticityKernel` no longer returns a Stokeslet in special cases).
2. ~Deprecates passing a non-string value for `viscosity_mu` and `poisson_ratio` to match the existing scalar kernels.~
2. Renames `viscosity_mu` and `poisson_ratio` to `viscosity_mu_name` and `poisson_ratio_name`.
3. Makes it an error to pass non-string values to these things. This matches all the other kernels.