### PR TITLE
Add SympyToPymbolicMapperWithSymbols

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -2108,14 +2108,6 @@
                 }
             },
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportImplicitOverride",
                 "range": {
                     "startColumn": 8,
@@ -8352,14 +8344,6 @@
                 }
             },
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportImplicitOverride",
                 "range": {
                     "startColumn": 8,
@@ -13404,6 +13388,62 @@
                 }
             },
             {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingTypeStubs",
                 "range": {
                     "startColumn": 5,
@@ -15834,22 +15874,6 @@
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 18,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
                     "startColumn": 71,
                     "endColumn": 76,
                     "lineCount": 1
@@ -16322,10 +16346,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportOperatorIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
+                    "startColumn": 18,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -16586,14 +16610,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 8,
@@ -16650,6 +16666,14 @@
                 }
             },
             {
+                "code": "reportOperatorIssue",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 48,
@@ -16662,14 +16686,6 @@
                 "range": {
                     "startColumn": 48,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -16826,10 +16842,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportOperatorIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
+                    "startColumn": 14,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             },
@@ -16954,14 +16970,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 67,
@@ -16970,42 +16978,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -17074,14 +17050,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 8,
@@ -17126,22 +17094,6 @@
                 "range": {
                     "startColumn": 43,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             }

--- a/sumpy/symbolic.py
+++ b/sumpy/symbolic.py
@@ -95,6 +95,9 @@ _find_symbolic_backend()
 
 # }}}
 
+
+# {{{ symbolic expressions
+
 if TYPE_CHECKING or not USE_SYMENGINE:
     import sympy as sym
 
@@ -169,6 +172,8 @@ else:
 
     def unevaluated_pow(a: Expr, b: complex | Expr) -> Expr:
         return Pow(a, b, evaluate=False)
+
+# }}}
 
 
 # {{{ debugging of sympy CSE via Maxima
@@ -253,6 +258,8 @@ def checked_cse(exprs, symbols=None):
 # }}}
 
 
+# {{{ pymbolic expressions
+
 def sym_real_norm_2(x: Matrix) -> Expr:
     return sqrt((x.T*x)[0, 0])
 
@@ -295,6 +302,10 @@ class SpatialConstant(prim.Variable):
 
         raise ValueError(f"expression is not a spatial constant: {expr!r}")
 
+# }}}
+
+
+# {{{ sympy <-> pymbolic interop
 
 class PymbolicToSympyMapper(PymbolicToSympyMapperBase):
     def map_spatial_constant(self, expr: SpatialConstant) -> Basic:
@@ -364,6 +375,45 @@ class PymbolicToSympyMapperWithSymbols(PymbolicToSympyMapper):
         return PymbolicToSympyMapper.map_call(self, expr)
 
 
+class SympyToPymbolicMapperWithSymbols(SympyToPymbolicMapper):
+    if USE_SYMENGINE:
+        @override
+        def map_Constant(self, expr: object) -> Expression:
+            if expr is pi:
+                return prim.Variable("pi")
+            elif expr is I:
+                return prim.Variable("I")
+            else:
+                return super().map_Constant(expr)
+    else:
+        @override
+        def map_NumberSymbol(self, expr: sym.NumberSymbol) -> Expression:
+            if expr is pi:
+                return prim.Variable("pi")
+            elif expr is I:
+                return prim.Variable("I")
+            else:
+                return super().map_NumberSymbol(expr)
+
+    @override
+    def not_supported(self, expr: object) -> Expression:
+        if getattr(expr, "is_Function", False):
+            function_name = self.function_name(expr)
+            if function_name in {"Hankel1", "BesselJ"}:
+                order, arg, nderivs = expr.args
+                if nderivs == 0:
+                    return prim.Variable({
+                        "Hankel1": "hankel_1",
+                        "BesselJ": "bessel_j",
+                    }[function_name])(self.rec(order), self.rec(arg))
+
+        return super().not_supported(expr)
+
+# }}}
+
+
+# {{{ symbolic functions
+
 from sympy import Function as SympyFunction
 
 
@@ -401,5 +451,7 @@ if not TYPE_CHECKING and USE_SYMENGINE:
 
     def Hankel1(*args):   # ruff:ignore[invalid-function-name]
         return sympify(_SympyHankel1(*args))
+
+# }}}
 
 # vim: fdm=marker

--- a/sumpy/test/test_misc.py
+++ b/sumpy/test/test_misc.py
@@ -921,6 +921,37 @@ def test_system_kernel_pickle(dim: int, cls: type[SystemKernel]) -> None:
 # }}}
 
 
+# {{{ test_symbolic_roundtrip_with_symbols
+
+def test_symbolic_roundtrip_with_symbols() -> None:
+    from pymbolic.primitives import Variable
+
+    s2p = sym.SympyToPymbolicMapperWithSymbols()
+    p2s = sym.PymbolicToSympyMapperWithSymbols()
+
+    sympy_exprs = [
+        sym.pi,
+        sym.Symbol("x"),
+        sym.sin(sym.Symbol("x")),
+    ]
+    for expr in sympy_exprs:
+        back = p2s.to_expr(s2p(expr))
+        assert sym.sympify(expr) == sym.sympify(back)
+
+    pymbolic_exprs = [
+        Variable("pi"),
+        Variable("x"),
+        sym.SpatialConstant("k"),
+        Variable("hankel_1")(0, Variable("x")),
+        Variable("bessel_j")(2, Variable("x")),
+    ]
+    for expr in pymbolic_exprs:
+        back = s2p(p2s.to_expr(expr))
+        assert expr == back
+
+# }}}
+
+
 # You can test individual routines by typing
 # $ python test_misc.py 'test_pde_check_kernels(_acf,
 #       KernelInfo(HelmholtzKernel(2), k=5), order=5)'


### PR DESCRIPTION
This is needed in #279 (mostly to move `pi` back from pymbolic).

`PymbolicToSympyMapperWithSymbols` also implements a special `map_subscript`, but that can't be unambiguously roundtripped, so I left it alone.