### PR TITLE
gpu-p2p small fixes

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -8319,22 +8319,6 @@
                 "code": "reportAny",
                 "range": {
                     "startColumn": 12,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 12,
                     "endColumn": 26,
                     "lineCount": 1
                 }
@@ -8343,7 +8327,7 @@
                 "code": "reportAny",
                 "range": {
                     "startColumn": 29,
-                    "endColumn": 53,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
             }

--- a/sumpy/p2p.py
+++ b/sumpy/p2p.py
@@ -754,6 +754,7 @@ class P2PFromCSR(P2PBase):
             if strength_dtype == source_dtype:
                 knl = lp.concatenate_arrays(knl, local_arrays, "local_isrc")
                 local_arrays = ["local_isrc"]
+                local_array_isrc_axis = [1]
                 local_array_sizes = [self.dim + self.strength_count]
                 local_array_dtypes = [source_dtype]
             # We try to mark the local arrays (sources, strengths)
@@ -811,8 +812,8 @@ class P2PFromCSR(P2PBase):
 
         is_gpu = not is_cl_cpu(actx)
         if is_gpu:
-            source_dtype = kwargs["sources"][0].dtype
-            strength_dtype = kwargs["strength"].dtype
+            source_dtype = sources[0].dtype
+            strength_dtype = kwargs["strength"][0].dtype
         else:
             # these are unused for not GPU and defeats the caching
             # set them to None to keep the caching across dtypes


### PR DESCRIPTION
  - Read the source dtype from the explicit sources parameter, which is not part of kwargs.
  - Read the strength dtype from the first strength array rather than from the containing sequence.
  - Keep one source-axis entry after concatenating the two local arrays to ensure the strict zip has matching lengths.